### PR TITLE
Fix minor Linux issues

### DIFF
--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -124,7 +124,7 @@ static std::string s_data_path;
 void SetDataPath(const char *data_path) { s_data_path = data_path; }
 
 std::string MakeDataPath(const char *file_rel_path) {
-    return s_data_path + "/" + file_rel_path;
+    return s_data_path + OS_GetDirSeparator() + file_rel_path;
 }
 
 std::shared_ptr<Engine> engine;

--- a/Media/Audio/AudioPlayer.cpp
+++ b/Media/Audio/AudioPlayer.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "Platform/Api.h"
+
 #include "Engine/Party.h"
 #include "Engine/ZlibWrapper.h"
 
@@ -117,11 +119,10 @@ void AudioPlayer::MusicPlayTrack(MusicID eTrack) {
         }
         currentMusicTrack = -1;
 
-        String file_path = StringPrintf("Music\\%d.mp3", eTrack);
+        String file_path = StringPrintf("Music%s%d.mp3", OS_GetDirSeparator().c_str(), eTrack);
         file_path = MakeDataPath(file_path.c_str());
-
         if (!FileExists(file_path.c_str())) {
-            logger->Warning(L"Music\\%d.mp3 not found", eTrack);
+            logger->Warning(L"Music%s%d.mp3 not found (%s)", OS_GetDirSeparator().c_str(), eTrack);
             return;
         }
 

--- a/Media/Audio/AudioPlayer.cpp
+++ b/Media/Audio/AudioPlayer.cpp
@@ -343,9 +343,10 @@ struct SoundHeader_mm7 {
 void AudioPlayer::LoadAudioSnd() {
     static_assert(sizeof(SoundHeader_mm7) == 52, "Wrong type size");
 
-    fAudioSnd.open(MakeDataPath("Sounds\\Audio.snd"), std::ios_base::binary);
+    std::string file_path = "Sounds" + OS_GetDirSeparator() + "Audio.snd";
+    fAudioSnd.open(MakeDataPath(file_path.c_str()), std::ios_base::binary);
     if (!fAudioSnd.good()) {
-        logger->Warning(L"Can't open file: %s", L"Sounds\\Audio.snd");
+        logger->Warning(L"Can't open file: %s", file_path.c_str());
         return;
     }
 

--- a/Platform/Api.h
+++ b/Platform/Api.h
@@ -35,3 +35,5 @@ bool OS_IfCtrlPressed();
 std::vector<std::string> OS_FindFiles(const std::string &folder, const std::string &mask);
 
 FILE* fcaseopen(char const* path, char const* mode);
+
+std::string OS_GetDirSeparator(void);

--- a/Platform/Lin/Lin.cpp
+++ b/Platform/Lin/Lin.cpp
@@ -48,15 +48,7 @@ Point OS_GetMouseCursorPos() {
 }
 
 bool OS_OpenConsole() {
-    /*if (AllocConsole()) {
-        freopen("conin$", "r", stdin);
-        freopen("conout$", "w", stdout);
-        freopen("conout$", "w", stderr);
-
-        return true;
-    }*/
-
-    return false;
+    return true;
 }
 
 std::vector<std::string> OS_FindFiles(const std::string& folder, const std::string& mask) {

--- a/Platform/Lin/Lin.cpp
+++ b/Platform/Lin/Lin.cpp
@@ -194,3 +194,7 @@ FILE *fcaseopen(char const *path, char const *mode)
     }
     return f;
 }
+
+std::string OS_GetDirSeparator() {
+    return "/";
+}

--- a/Platform/Win/Win.cpp
+++ b/Platform/Win/Win.cpp
@@ -73,3 +73,7 @@ std::vector<std::string> OS_FindFiles(const std::string &folder, const std::stri
 FILE *fcaseopen(char const *path, char const *mode) {
     return fopen(path, mode);
 }
+
+std::string OS_GetDirSeparator() {
+    return "\\";
+}


### PR DESCRIPTION
- Expose a function `OS_GetDirSeparator()` to allow to use `/` or `\` on Linux or Windows
- No need to do something in `OS_OpenConsole()` in Linux, stdin/stdout can be used

The music and sound effects are now working on Linux.
The logs are "fuzzy" sometimes but it should be nice if someone can confirm it is a Linux issue or not.

By fuzzy, I mean that time may be repeated several times on same line
```
[2020/04/20 21:34:04] [2020/04/20 21:34:05] [2020/04/20 21:34:05] [2020/04/20 21:34:06] [2020/04/20 21:34:06] [2020/04/20 21:34:06] [2020/04/20 21:34:06] [2020/04/20 21:34:06] [2020/04/20 21:34:07] Failed to load sound ""
```