### PR TITLE
Fix for doors being hard to interact with outdoors.

### DIFF
--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -403,8 +403,8 @@ void Engine::PushStationaryLights(int a2) {
 bool Engine::_44EEA7() {  // cursor picking - particle update
     float depth;               // ST00_4@9
     __int64 v6;                // kr00_8@21
-    Vis_SelectionFilter *v10;  // [sp+10h] [bp-18h]@2
-    Vis_SelectionFilter *v11;  // [sp+14h] [bp-14h]@2
+    Vis_SelectionFilter *sprite_filter;  // [sp+10h] [bp-18h]@2
+    Vis_SelectionFilter *face_filter;  // [sp+14h] [bp-14h]@2
 
     ++qword_5C6DF0;
     particle_engine->UpdateParticles();
@@ -413,22 +413,22 @@ bool Engine::_44EEA7() {  // cursor picking - particle update
     // x = cursor.y;
     // y = cursor.x;
     if (sub_4637E0_is_there_popup_onscreen()) {
-        v11 = &vis_face_filter;
-        v10 = &vis_sprite_filter_2;
+        face_filter = &vis_face_filter;
+        sprite_filter = &vis_sprite_filter_2;
         depth = pIndoorCameraD3D->GetPickDepth();
     } else {
         if (config->IsTargetingMode()) {
-            v11 = &vis_face_filter;
-            v10 = &vis_sprite_filter_1;
+            face_filter = &vis_face_filter;
+            sprite_filter = &vis_sprite_filter_1;
         } else {
-            v11 = &vis_face_filter;
-            v10 = &vis_sprite_filter_4;
+            face_filter = &vis_face_filter;
+            sprite_filter = &vis_sprite_filter_4;
         }
         depth = 5120.0;
     }
     // depth = v2;
 
-    PickMouse(depth, pt.x, pt.y, false, v10, v11);
+    PickMouse(depth, pt.x, pt.y, false, sprite_filter, face_filter);
     lightmap_builder->StationaryLightsCount = 0;
     lightmap_builder->MobileLightsCount = 0;
     decal_builder->DecalsCount = 0;

--- a/Engine/EngineConfig.h
+++ b/Engine/EngineConfig.h
@@ -67,7 +67,7 @@ class EngineConfig {
     inline bool ForceRedraw() const { return flags2 & GAME_FLAGS_2_FORCE_REDRAW; }
            void SetForceRedraw(bool redraw);
     inline bool AllowDynamicBrigtness() const { return flags2 & GAME_FLAGS_2_ALLOW_DYNAMIC_BRIGHTNESS; }
-    inline bool RunInWindow() const { return dword_6BE368_debug_settings_2 & DEBUG_SETTINGS_RUN_IN_WIDOW; }
+    inline bool RunInWindow() const { return run_in_window & DEBUG_SETTINGS_RUN_IN_WIDOW; }
 
     inline void ToggleDebugTownPortal() { debug_town_portal = !debug_town_portal; }
     inline void ToggleDebugWizardEye() { debug_wizard_eye = !debug_wizard_eye; }
@@ -85,7 +85,7 @@ class EngineConfig {
     inline void ToggleDebugSeasonsChange() { seasons_change = !seasons_change; }
 
     // DEBUG_SETTINGS_*
-    int dword_6BE368_debug_settings_2 = DEBUG_SETTINGS_RUN_IN_WIDOW;
+    int run_in_window = DEBUG_SETTINGS_RUN_IN_WIDOW;
 
     // GAME_FLAGS_1_*
     int flags1 = GAME_FLAGS_1_40 | GAME_FLAGS_1_800;

--- a/Engine/EngineConfigFactory.cpp
+++ b/Engine/EngineConfigFactory.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<EngineConfig> EngineConfigFactory::CreateFromCommandLine(const s
     // config->renderer_name = "OpenGL";
 
     if (FindCaseInsensitive(cmd, "-window")) {
-        config->dword_6BE368_debug_settings_2 |= DEBUG_SETTINGS_RUN_IN_WIDOW;
+        config->run_in_window |= DEBUG_SETTINGS_RUN_IN_WIDOW;
     }
     if (FindCaseInsensitive(cmd, "-nointro")) {
         config->no_intro = true;

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1174,7 +1174,7 @@ int IndoorLocation::GetSector(int sX, int sY, int sZ) {
 
         // logger->Warning("Sector[%u]", i);
         int FloorsAndPortals = pSector->uNumFloors + pSector->uNumPortals;
-      
+
         // nothing in secotr to check against so skip
         if (!FloorsAndPortals) continue;
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -494,7 +494,7 @@ struct BLVFace {  // 60h
 /*   94 */
 #pragma pack(push, 1)
 struct BLVFaceExtra {  // 24h
-    bool HasEventint();
+    bool HasEventHint();
 
     int16_t field_0;
     int16_t field_2;
@@ -723,7 +723,7 @@ extern BLVRenderParams *pBLVRenderParams;
 // void PrepareBspRenderList_BLV();
 // void AddBspNodeToRenderList(unsigned int node_id);
 // void sub_4406BC(unsigned int node_id, unsigned int uFirstNode);  // idb
-char DoInteractionWithTopmostZObject(int a1, int a2);
+char DoInteractionWithTopmostZObject(int pid);
 // int sub_4AAEA6_transform(struct RenderVertexSoft *a1);
 unsigned int FaceFlowTextureOffset(unsigned int uFaceID);  // idb
 void BLV_UpdateUserInputAndOther();

--- a/Engine/Graphics/Outdoor.cpp
+++ b/Engine/Graphics/Outdoor.cpp
@@ -1230,7 +1230,7 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
                 if (face.HasEventHint()) {
                     face.uAttributes |= FACE_HAS_EVENT;
                 } else {
-                    face.uAttributes &= ~FACE_HAS_EVENT; 
+                    face.uAttributes &= ~FACE_HAS_EVENT;
                 }
             }
         }

--- a/Engine/Graphics/Outdoor.cpp
+++ b/Engine/Graphics/Outdoor.cpp
@@ -1228,9 +1228,9 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
         for (ODMFace &face : model.pFaces) {
             if (face.sCogTriggeredID) {
                 if (face.HasEventHint()) {
-                    face.uAttributes |= FACE_HAS_EVENT_HINT;
+                    face.uAttributes |= FACE_HAS_EVENT;
                 } else {
-                    face.uAttributes &= ~FACE_HAS_EVENT_HINT;  // ~0x00001000
+                    face.uAttributes &= ~FACE_HAS_EVENT; 
                 }
             }
         }

--- a/Engine/Graphics/Viewport.cpp
+++ b/Engine/Graphics/Viewport.cpp
@@ -316,20 +316,21 @@ void Engine::OnGameViewportClick() {
     int pEventID;     // ecx@21
     SpriteObject a1;  // [sp+Ch] [bp-80h]@1
 
-    int clickable_distance = 512;
+    int16_t clickable_distance = 512;
 
     // bug fix - stops you entering shops while dialog still open.
     if (current_screen_type == CURRENT_SCREEN::SCREEN_NPC_DIALOGUE)
         return;
 
-    int v0 = vis->get_picked_object_zbuf_val();
-    int distance = HEXRAYS_HIWORD(v0);
+    auto pidAndDepth = vis->get_picked_object_zbuf_val();
+    uint16_t pid = pidAndDepth.object_pid;
+    int16_t distance = pidAndDepth.depth;
     bool in_range = distance < clickable_distance;
     // else
     //  v0 = render->pActiveZBuffer[v1->x + pSRZBufferLineOffsets[v1->y]];
 
-    if (PID_TYPE(v0) == OBJECT_Item) {
-        int item_id = PID_ID(v0);
+    if (PID_TYPE(pid) == OBJECT_Item) {
+        int item_id = PID_ID(pid);
         // v21 = (signed int)(unsigned __int16)v0 >> 3;
         if (pSpriteObjects[item_id].IsUnpickable() ||
             item_id >= 1000 || !pSpriteObjects[item_id].uObjectDescID || !in_range) {
@@ -339,8 +340,8 @@ void Engine::OnGameViewportClick() {
         } else {
             ItemInteraction(item_id);
         }
-    } else if (PID_TYPE(v0) == OBJECT_Actor) {
-        int mon_id = PID_ID(v0);
+    } else if (PID_TYPE(pid) == OBJECT_Actor) {
+        int mon_id = PID_ID(pid);
         // a2.y = v16;
         if (pActors[mon_id].uAIState == Dead) {
             if (in_range)
@@ -364,18 +365,18 @@ void Engine::OnGameViewportClick() {
                 pPlayers[uActiveCharacter]->uQuickSpell)) {
             pMessageQueue_50CBD0->AddGUIMessage(UIMSG_CastQuickSpell, 0, 0);
         }
-    } else if (PID_TYPE(v0) == OBJECT_Decoration) {
-        int id = PID_ID(v0);
+    } else if (PID_TYPE(pid) == OBJECT_Decoration) {
+        int id = PID_ID(pid);
         if (distance - pDecorationList->GetDecoration(pLevelDecorations[id].uDecorationDescID)->uRadius >= clickable_distance) {
             if (pParty->pPickedItem.uItemID) {
                 DropHeldItem();
             }
         } else {
-            DecorationInteraction(id, v0);
+            DecorationInteraction(id, pid);
         }
-    } else if (PID_TYPE(v0) == OBJECT_BModel && in_range) {
+    } else if (PID_TYPE(pid) == OBJECT_BModel && in_range) {
         if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
-            if (!pIndoor->pFaces[PID_ID(v0)].Clickable()) {
+            if (!pIndoor->pFaces[PID_ID(pid)].Clickable()) {
                 if (!pParty->pPickedItem.uItemID) {
                     GameUI_StatusBar_NothingHere();
                     if (!pParty->pPickedItem.uItemID)
@@ -384,11 +385,11 @@ void Engine::OnGameViewportClick() {
                     DropHeldItem();
                 }
             } else {
-                pEventID = pIndoor->pFaceExtras[pIndoor->pFaces[PID_ID(v0)].uFaceExtraID].uEventID;
-                EventProcessor(pEventID, (unsigned __int16)v0, 1);
+                pEventID = pIndoor->pFaceExtras[pIndoor->pFaces[PID_ID(pid)].uFaceExtraID].uEventID;
+                EventProcessor(pEventID, pid, 1);
             }
         } else if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {
-            if (!pOutdoor->pBModels[(signed int)(v0 & 0xFFFF) >> 9].pFaces[PID_ID(v0) & 0x3F].Clickable()) {
+            if (!pOutdoor->pBModels[(signed int)(pid) >> 9].pFaces[PID_ID(pid) & 0x3F].Clickable()) {
                 if (!pParty->pPickedItem.uItemID) {
                     GameUI_StatusBar_NothingHere();
                     if (!pParty->pPickedItem.uItemID)
@@ -397,10 +398,10 @@ void Engine::OnGameViewportClick() {
                     DropHeldItem();
                 }
             } else {
-                pEventID = pOutdoor->pBModels[(signed int)(v0 & 0xFFFF) >> 9]
-                               .pFaces[PID_ID(v0) & 0x3F]
+                pEventID = pOutdoor->pBModels[(signed int)(pid) >> 9]
+                               .pFaces[PID_ID(pid) & 0x3F]
                                .sCogTriggeredID;
-                EventProcessor(pEventID, (unsigned __int16)v0, 1);
+                EventProcessor(pEventID, pid, 1);
             }
         }
     } else if (pParty->pPickedItem.uItemID) {

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -493,24 +493,34 @@ void Vis::SortVectors_x(RenderVertexSoft *pArray, int start, int end) {
     }
 }
 
+Vis_PIDAndDepth InvalidPIDAndDepth() {
+    Vis_PIDAndDepth result;
+    result.depth = 0;
+    result.object_pid = PID_INVALID;
+    return result;
+}
+
 //----- (004C1BAA) --------------------------------------------------------
-int Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
+Vis_PIDAndDepth Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
     switch (info->object_type) {
         case VisObjectType_Sprite:
         case VisObjectType_Face: {
-            return info->sZValue;
+            Vis_PIDAndDepth result;
+            result.depth = info->depth;
+            result.object_pid = info->object_pid;
+            return result;
         }
 
         default:
             log->Warning(
                 "Undefined type requested for: CVis::get_object_zbuf_val()");
-            return -1;
+            return InvalidPIDAndDepth();
     }
 }
 
 //----- (004C1BF1) --------------------------------------------------------
-int Vis::get_picked_object_zbuf_val() {
-    if (!default_list.uNumPointers) return -1;
+Vis_PIDAndDepth Vis::get_picked_object_zbuf_val() {
+    if (!default_list.uNumPointers) return InvalidPIDAndDepth();
 
     return get_object_zbuf_val(default_list.object_pointers[0]);
 }

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -1410,8 +1410,8 @@ bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
 
             if (filter->object_type != OBJECT_BLVDoor) return true;
 
-            auto what_is_this = face_attrib & filter->no_at_ai_state;
-            if (no_event || what_is_this)  // face_attrib = 0x2009408 incorrect
+            auto invalid_face_attrib = face_attrib & filter->no_at_ai_state;
+            if (no_event || invalid_face_attrib)  // face_attrib = 0x2009408 incorrect
                 return false;
             return (face_attrib & filter->at_ai_state) != 0;
         }

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -20,17 +20,17 @@ using EngineIoc = Engine_::IocContainer;
 static Vis_SelectionList Vis_static_sub_4C1944_stru_F8BDE8;
 
 Vis_SelectionFilter vis_sprite_filter_1 = {
-    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, 2};  // 00F93E1C
+    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType}; // 00F93E1C
 Vis_SelectionFilter vis_sprite_filter_2 = {
-    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, 2};  // 00F93E30
-Vis_SelectionFilter vis_face_filter = {VisObjectType_Face, OBJECT_Any, -1, 0,
-                                       0};  // 00F93E44
-Vis_SelectionFilter vis_door_filter = {VisObjectType_Face, OBJECT_BLVDoor, -1,
-                                       0x100000, 0};  // 00F93E58
+    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType}; // 00F93E30
+Vis_SelectionFilter vis_face_filter = {
+    VisObjectType_Face, OBJECT_Any, -1, 0, None}; // 00F93E44
+Vis_SelectionFilter vis_door_filter = {
+    VisObjectType_Face, OBJECT_BLVDoor, -1, FACE_HAS_EVENT, None }; // 00F93E58
 Vis_SelectionFilter vis_sprite_filter_3 = {
-    VisObjectType_Sprite, OBJECT_Decoration, -1, 0, 4};  // 00F93E6C
-Vis_SelectionFilter vis_sprite_filter_4 = {VisObjectType_Any, OBJECT_Item, -1,
-                                           0, 0};  // static to sub_44EEA7
+    VisObjectType_Sprite, OBJECT_Decoration, -1, 0, ExclusionIfNoEvent};  // 00F93E6C
+Vis_SelectionFilter vis_sprite_filter_4 = {
+    VisObjectType_Any, OBJECT_Item, -1, 0, None };  // static to sub_44EEA7
 
 //----- (004C1026) --------------------------------------------------------
 Vis_ObjectInfo *Vis::DetermineFacetIntersection(BLVFace *face, unsigned int pid,
@@ -404,19 +404,19 @@ void Vis::PickOutdoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
 
 //----- (004C1944) --------------------------------------------------------
 unsigned short Vis::PickClosestActor(int object_id, unsigned int pick_depth,
-                                     int a4, int a5, int a6) {
-    Vis_SelectionFilter v8;  // [sp+18h] [bp-20h]@3
+                                     VisSelectFlags select_flags, int not_at_ai_state, int at_ai_state) {
+    Vis_SelectionFilter selectionFilter;  // [sp+18h] [bp-20h]@3
 
     static Vis_SelectionList Vis_static_sub_4C1944_stru_F8BDE8;
 
-    v8.object_type = VisObjectType_Sprite;
-    v8.object_id = object_id;
-    v8.at_ai_state = a6;
-    v8.no_at_ai_state = a5;
-    v8.select_flags = a4;
+    selectionFilter.vis_object_type = VisObjectType_Sprite;
+    selectionFilter.object_type = object_id;
+    selectionFilter.at_ai_state = at_ai_state;
+    selectionFilter.no_at_ai_state = not_at_ai_state;
+    selectionFilter.select_flags = select_flags;
     Vis_static_sub_4C1944_stru_F8BDE8.uNumPointers = 0;
     PickBillboards_Keyboard(pick_depth, &Vis_static_sub_4C1944_stru_F8BDE8,
-                            &v8);
+                            &selectionFilter);
     Vis_static_sub_4C1944_stru_F8BDE8.create_object_pointers(
         Vis_SelectionList::Unique);
     sort_object_pointers(Vis_static_sub_4C1944_stru_F8BDE8.object_pointers, 0,
@@ -498,15 +498,7 @@ int Vis::get_object_zbuf_val(Vis_ObjectInfo *info) {
     switch (info->object_type) {
         case VisObjectType_Sprite:
         case VisObjectType_Face: {
-            // return info->sZValue;
-
-            struct {
-                unsigned short object_pid;
-                short depth;
-            } res;
-            res.depth = info->depth;
-            res.object_pid = info->object_pid;
-            return *(int *)&res;
+            return info->sZValue;
         }
 
         default:
@@ -1325,7 +1317,7 @@ void Vis::PickBillboards_Keyboard(float pick_depth, Vis_SelectionList *list,
 //----- (004C0791) --------------------------------------------------------
 bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
                                Vis_SelectionFilter *filter) {
-    switch (filter->object_type) {
+    switch (filter->vis_object_type) {
         case VisObjectType_Any:
             return true;
 
@@ -1345,14 +1337,12 @@ bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
                              int)uD3DBillboardIdx_or_pBLVFace_or_pODMFace]
                          .sParentBillboardID]
                         .object_pid);
-            if (filter->select_flags & 2) {
-                if (object_type == filter->object_id) return false;
-                return true;
+            if (filter->select_flags & ExcludeType) {
+                return object_type != filter->object_type;
             }
-            if (filter->select_flags & 4) {
-                // v8 = filter->object_id;
-                if (object_type != filter->object_id) return true;
-                if (filter->object_id != OBJECT_Decoration) {
+            if (filter->select_flags & ExclusionIfNoEvent) {
+                if (object_type != filter->object_type) return true;
+                if (filter->object_type != OBJECT_Decoration) {
                     log->Warning(
                         "Unsupported \"exclusion if no event\" type in "
                         "CVis::is_part_of_selection");
@@ -1363,25 +1353,31 @@ bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
                     return true;
                 return pLevelDecorations[object_idx].IsInteractive();
             }
-            if (object_type == filter->object_id) {
+            if (object_type == filter->object_type) {
                 if (object_type != OBJECT_Actor) {
                     log->Warning("Default case reached in VIS");
                     return true;
                 }
 
                 // v10 = &pActors[object_idx];
-                int result = 1 << HEXRAYS_LOBYTE(pActors[object_idx].uAIState);
-                if (result & filter->no_at_ai_state ||
-                    !(result & filter->at_ai_state) ||
-                    filter->select_flags & 8 &&
-                        (result = MonsterStats::BelongsToSupertype(
-                             pActors[object_idx].pMonsterInfo.uID,
-                             MONSTER_SUPERTYPE_UNDEAD)) == 0)
-                    return false;
-                if (!(filter->select_flags & 1)) return true;
+                int aiState = 1 << HEXRAYS_LOBYTE(pActors[object_idx].uAIState);
 
-                result = pActors[object_idx].GetActorsRelation(nullptr);
-                if (result == 0) return false;
+                if (aiState & filter->no_at_ai_state)
+                    return false;
+                if (!(aiState & filter->at_ai_state))
+                    return false;
+
+                auto only_target_undead = filter->select_flags & TargetUndead;
+                auto target_not_undead = MonsterStats::BelongsToSupertype(pActors[object_idx].pMonsterInfo.uID, MONSTER_SUPERTYPE_UNDEAD) == 0;
+
+                if (only_target_undead && target_not_undead)
+                    return false;
+
+                if (!(filter->select_flags & VisSelectFlags_1)) 
+                    return true;
+
+                auto relation = pActors[object_idx].GetActorsRelation(nullptr);
+                if (relation == 0) return false;
                 return true;
             }
             return false;
@@ -1402,10 +1398,10 @@ bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
                 assert(false);
             }
 
-            if (filter->object_id != OBJECT_BLVDoor) return true;
-            if (no_event ||
-                face_attrib &
-                    filter->no_at_ai_state)  // face_attrib = 0x2009408 incorrect
+            if (filter->object_type != OBJECT_BLVDoor) return true;
+
+            auto what_is_this = face_attrib & filter->no_at_ai_state;
+            if (no_event || what_is_this)  // face_attrib = 0x2009408 incorrect
                 return false;
             return (face_attrib & filter->at_ai_state) != 0;
         }

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -20,13 +20,13 @@ using EngineIoc = Engine_::IocContainer;
 static Vis_SelectionList Vis_static_sub_4C1944_stru_F8BDE8;
 
 Vis_SelectionFilter vis_sprite_filter_1 = {
-    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType}; // 00F93E1C
+    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType};  // 00F93E1C
 Vis_SelectionFilter vis_sprite_filter_2 = {
-    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType}; // 00F93E30
+    VisObjectType_Sprite, OBJECT_Decoration, 0, 0, ExcludeType};  // 00F93E30
 Vis_SelectionFilter vis_face_filter = {
-    VisObjectType_Face, OBJECT_Any, -1, 0, None}; // 00F93E44
+    VisObjectType_Face, OBJECT_Any, -1, 0, None};  // 00F93E44
 Vis_SelectionFilter vis_door_filter = {
-    VisObjectType_Face, OBJECT_BLVDoor, -1, FACE_HAS_EVENT, None }; // 00F93E58
+    VisObjectType_Face, OBJECT_BLVDoor, -1, FACE_HAS_EVENT, None };  // 00F93E58
 Vis_SelectionFilter vis_sprite_filter_3 = {
     VisObjectType_Sprite, OBJECT_Decoration, -1, 0, ExclusionIfNoEvent};  // 00F93E6C
 Vis_SelectionFilter vis_sprite_filter_4 = {
@@ -1373,7 +1373,7 @@ bool Vis::is_part_of_selection(void *uD3DBillboardIdx_or_pBLVFace_or_pODMFace,
                 if (only_target_undead && target_not_undead)
                     return false;
 
-                if (!(filter->select_flags & VisSelectFlags_1)) 
+                if (!(filter->select_flags & VisSelectFlags_1))
                     return true;
 
                 auto relation = pActors[object_idx].GetActorsRelation(nullptr);

--- a/Engine/Graphics/Vis.h
+++ b/Engine/Graphics/Vis.h
@@ -34,15 +34,17 @@ extern Vis_SelectionFilter vis_sprite_filter_3;  // 00F93E6C
 extern Vis_SelectionFilter vis_sprite_filter_4;  // static to sub_44EEA7
 
 #pragma pack(push, 1)
+struct Vis_PIDAndDepth {
+    uint16_t object_pid;
+    int16_t depth;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
 struct Vis_ObjectInfo {
     void *object;
-    union {
-        int sZValue;
-        struct {
-            uint16_t object_pid;
-            int16_t depth;
-        };
-    };
+    uint16_t object_pid;
+    int16_t depth;
     VisObjectType object_type;
 };
 #pragma pack(pop)
@@ -126,8 +128,8 @@ class Vis {
                                     VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
     void _4C1A02();
     void SortVectors_x(RenderVertexSoft *pArray, int start, int end);
-    int get_object_zbuf_val(Vis_ObjectInfo *info);
-    int get_picked_object_zbuf_val();
+    Vis_PIDAndDepth get_object_zbuf_val(Vis_ObjectInfo *info);
+    Vis_PIDAndDepth get_picked_object_zbuf_val();
     bool Intersect_Ray_Face(struct RenderVertexSoft *pRayStart,
                             struct RenderVertexSoft *pRayEnd, float *pDepth,
                             RenderVertexSoft *Intersection, BLVFace *pFace,

--- a/Engine/Graphics/Vis.h
+++ b/Engine/Graphics/Vis.h
@@ -7,14 +7,23 @@ enum VisObjectType : uint32_t {
     VisObjectType_Face = 2
 };
 
+enum VisSelectFlags : uint32_t {
+    None = 0,
+    VisSelectFlags_1 = 1, // not set in any of the standard filters. Used to check something that seems to be ally/enemy-based?
+    ExcludeType = 2,
+    ExclusionIfNoEvent = 4,
+    TargetUndead = 8
+};
+
 /*  150 */
 #pragma pack(push, 1)
+// NOTE: The variable names here are correct when the filter is used for VisObjectType_Sprite, but wrong for VisObjectType_Face
 struct Vis_SelectionFilter {  // stru157
-    VisObjectType object_type;
-    int object_id;  // OBJECT_Actor, OBJECT_Player etc
+    VisObjectType vis_object_type;
+    int object_type;  // OBJECT_Actor, OBJECT_Player etc
     int at_ai_state;
     int no_at_ai_state;
-    int select_flags;
+    VisSelectFlags select_flags;
 };
 #pragma pack(pop)
 extern Vis_SelectionFilter vis_sprite_filter_1;  // 00F93E1C
@@ -28,7 +37,7 @@ extern Vis_SelectionFilter vis_sprite_filter_4;  // static to sub_44EEA7
 struct Vis_ObjectInfo {
     void *object;
     union {
-        // int sZValue;
+        int sZValue;
         struct {
             uint16_t object_pid;
             int16_t depth;
@@ -114,7 +123,7 @@ class Vis {
     bool IsPointInsideD3DBillboard(struct RenderBillboardD3D *a1, float x,
                                    float y);
     unsigned short PickClosestActor(int object_id, unsigned int pick_depth,
-                                    int a4, int a5, int a6);
+                                    VisSelectFlags selectFlags, int not_at_ai_state, int at_ai_state);
     void _4C1A02();
     void SortVectors_x(RenderVertexSoft *pArray, int start, int end);
     int get_object_zbuf_val(Vis_ObjectInfo *info);

--- a/Engine/Graphics/Vis.h
+++ b/Engine/Graphics/Vis.h
@@ -9,7 +9,7 @@ enum VisObjectType : uint32_t {
 
 enum VisSelectFlags : uint32_t {
     None = 0,
-    VisSelectFlags_1 = 1, // not set in any of the standard filters. Used to check something that seems to be ally/enemy-based?
+    VisSelectFlags_1 = 1,  // not set in any of the standard filters. Used to check something that seems to be ally/enemy-based?
     ExcludeType = 2,
     ExclusionIfNoEvent = 4,
     TargetUndead = 8

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -3875,10 +3875,10 @@ int stru319::_427546(int a2) {
     return result;
 }
 //----- (0042F184) --------------------------------------------------------
-int stru319::FindClosestActor(int pick_depth, int a3, int a4) {
+int stru319::FindClosestActor(int pick_depth, int a3 /*Relates to targeting/not targeting allies?*/, int target_undead) {
     int v4;       // edi@1
     stru319 *v5;  // esi@1
-    int v6;       // eax@2
+    int select_flags;       // eax@2
     int v7;       // eax@4
     //  int result; // eax@5
     //  int *v9; // edx@8
@@ -3911,9 +3911,9 @@ int stru319::FindClosestActor(int pick_depth, int a3, int a4) {
     v24 = this;
     // if ( render->pRenderD3D )
     {
-        v6 = a3 != 0;
-        if (a4) v6 |= 8;
-        v7 = vis->PickClosestActor(OBJECT_Actor, pick_depth, v6, 657456, -1);
+        select_flags = a3 != 0;
+        if (target_undead) select_flags |= TargetUndead;
+        v7 = vis->PickClosestActor(OBJECT_Actor, pick_depth, static_cast<VisSelectFlags>(select_flags), 657456, -1);
         if (v7 != -1)
             return (unsigned __int16)v7;
         else

--- a/Engine/Objects/Actor.h
+++ b/Engine/Objects/Actor.h
@@ -17,7 +17,7 @@ struct stru319 {
 
     int which_player_to_attack(struct Actor *pActor);
     int _427546(int a2);
-    int FindClosestActor(int a2, int a3, int a4);
+    int FindClosestActor(int pick_depth, int a3, int target_undead);
 
     char field_0;
 

--- a/GUI/GUIWindow.h
+++ b/GUI/GUIWindow.h
@@ -73,7 +73,7 @@ enum UIMessageType : uint32_t {
     UIMSG_ClickInstallRemoveQuickSpellBtn = 88,
 
     UIMSG_OnTravelByFoot = 90,
-    UIMSG_CHANGE_LOCATION_ClickCencelBtn = 91,
+    UIMSG_CHANGE_LOCATION_ClickCancelBtn = 91,
     UIMSG_ShowStatus_DateTime = 92,
     UIMSG_ShowStatus_ManaHP = 93,
     UIMSG_ShowStatus_Player = 94,

--- a/GUI/UI/UIGame.cpp
+++ b/GUI/UI/UIGame.cpp
@@ -1271,7 +1271,7 @@ void GameUI_WritePointedObjectStatusString() {
     int invmatrixindex;                // eax@41
     ItemGen *pItemGen;                 // ecx@44
     int v16;                           // ecx@46
-    signed int pickedObjectPID;        // eax@55
+    signed int pickedObject;        // eax@55
     signed int v18b;
     signed int pickedObjectID = 0;     // ecx@63
     BLVFace *pFace;                    // eax@69
@@ -1302,10 +1302,12 @@ void GameUI_WritePointedObjectStatusString() {
             }
 
             auto vis = EngineIoc::ResolveVis();
-            pickedObjectPID = vis->get_picked_object_zbuf_val();
-            pMouse->uPointingObjectID = (unsigned __int16)pickedObjectPID;
-            pickedObjectID = (signed)PID_ID(pickedObjectPID);
-            if (PID_TYPE(pickedObjectPID) == OBJECT_Item) {
+
+            // get_picked_object_zbuf_val contains both the pid and the depth
+            pickedObject = vis->get_picked_object_zbuf_val();
+            pMouse->uPointingObjectID = (unsigned __int16)pickedObject;
+            pickedObjectID = (signed)PID_ID(pickedObject);
+            if (PID_TYPE(pickedObject) == OBJECT_Item) {
                 if (pObjectList
                         ->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID]
                         .uFlags &
@@ -1316,7 +1318,7 @@ void GameUI_WritePointedObjectStatusString() {
                     uLastPointedObjectID = 0;
                     return;
                 }
-                if (pickedObjectPID >= 0x2000000u ||
+                if (pickedObject >= 0x2000000u ||
                     pParty->pPickedItem.uItemID) {
                     GameUI_StatusBar_Set(pSpriteObjects[pickedObjectID]
                                              .containing_item.GetDisplayName());
@@ -1326,7 +1328,7 @@ void GameUI_WritePointedObjectStatusString() {
                         .containing_item.GetDisplayName()
                         .c_str()));  // Get %s
                 }  // intentional fallthrough
-            } else if (PID_TYPE(pickedObjectPID) == OBJECT_Decoration) {
+            } else if (PID_TYPE(pickedObject) == OBJECT_Decoration) {
                 if (!pLevelDecorations[pickedObjectID].uEventID) {
                     if (pLevelDecorations[pickedObjectID].IsInteractive())
                         pText = pNPCTopics[stru_5E4C90_MapPersistVars._decor_events
@@ -1341,11 +1343,11 @@ void GameUI_WritePointedObjectStatusString() {
                         GameUI_StatusBar_Set(hintString);
                     }
                 }  // intentional fallthrough
-            } else if (PID_TYPE(pickedObjectPID) == OBJECT_BModel) {
-                if (pickedObjectPID < 0x2000000u) {
+            } else if (PID_TYPE(pickedObject) == OBJECT_BModel) {
+                if (pickedObject < 0x2000000u) {
                     char *newString = nullptr;
                     if (uCurrentlyLoadedLevelType != LEVEL_Indoor) {
-                        v18b = PID_ID(pickedObjectPID) >> 6;
+                        v18b = PID_ID(pickedObject) >> 6;
                         short triggeredId = pOutdoor->pBModels[v18b].pFaces[pickedObjectID & 0x3F].sCogTriggeredID;
                         if (triggeredId != 0) {
                             newString = GetEventHintString(
@@ -1382,8 +1384,8 @@ void GameUI_WritePointedObjectStatusString() {
                 bForceDrawFooter = 1;
                 uLastPointedObjectID = 0;
                 return;
-            } else if (PID_TYPE(pickedObjectPID) == OBJECT_Actor) {
-                if (pickedObjectPID >= 0x2000000) {
+            } else if (PID_TYPE(pickedObject) == OBJECT_Actor) {
+                if (pickedObject >= 0x2000000) {
                     pMouse->uPointingObjectID = 0;
                     if (uLastPointedObjectID != 0) {
                         game_ui_status_bar_string.clear();

--- a/GUI/UI/UIGame.cpp
+++ b/GUI/UI/UIGame.cpp
@@ -1271,7 +1271,7 @@ void GameUI_WritePointedObjectStatusString() {
     int invmatrixindex;                // eax@41
     ItemGen *pItemGen;                 // ecx@44
     int v16;                           // ecx@46
-    signed int pickedObject;        // eax@55
+    Vis_PIDAndDepth pickedObject;        // eax@55
     signed int v18b;
     signed int pickedObjectID = 0;     // ecx@63
     BLVFace *pFace;                    // eax@69
@@ -1305,20 +1305,17 @@ void GameUI_WritePointedObjectStatusString() {
 
             // get_picked_object_zbuf_val contains both the pid and the depth
             pickedObject = vis->get_picked_object_zbuf_val();
-            pMouse->uPointingObjectID = (unsigned __int16)pickedObject;
-            pickedObjectID = (signed)PID_ID(pickedObject);
-            if (PID_TYPE(pickedObject) == OBJECT_Item) {
-                if (pObjectList
-                        ->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID]
-                        .uFlags &
-                    0x10) {
+            pMouse->uPointingObjectID = pickedObject.object_pid;
+            pickedObjectID = (signed)PID_ID(pickedObject.object_pid);
+            if (PID_TYPE(pickedObject.object_pid) == OBJECT_Item) {
+                if (pObjectList->pObjects[pSpriteObjects[pickedObjectID].uObjectDescID].uFlags & OBJECT_DESC_UNPICKABLE) {
                     pMouse->uPointingObjectID = 0;
                     game_ui_status_bar_string.clear();
                     bForceDrawFooter = 1;
                     uLastPointedObjectID = 0;
                     return;
                 }
-                if (pickedObject >= 0x2000000u ||
+                if (pickedObject.depth >= 0x200u ||
                     pParty->pPickedItem.uItemID) {
                     GameUI_StatusBar_Set(pSpriteObjects[pickedObjectID]
                                              .containing_item.GetDisplayName());
@@ -1328,7 +1325,7 @@ void GameUI_WritePointedObjectStatusString() {
                         .containing_item.GetDisplayName()
                         .c_str()));  // Get %s
                 }  // intentional fallthrough
-            } else if (PID_TYPE(pickedObject) == OBJECT_Decoration) {
+            } else if (PID_TYPE(pickedObject.object_pid) == OBJECT_Decoration) {
                 if (!pLevelDecorations[pickedObjectID].uEventID) {
                     if (pLevelDecorations[pickedObjectID].IsInteractive())
                         pText = pNPCTopics[stru_5E4C90_MapPersistVars._decor_events
@@ -1343,11 +1340,11 @@ void GameUI_WritePointedObjectStatusString() {
                         GameUI_StatusBar_Set(hintString);
                     }
                 }  // intentional fallthrough
-            } else if (PID_TYPE(pickedObject) == OBJECT_BModel) {
-                if (pickedObject < 0x2000000u) {
+            } else if (PID_TYPE(pickedObject.object_pid) == OBJECT_BModel) {
+                if (pickedObject.depth < 0x200u) {
                     char *newString = nullptr;
                     if (uCurrentlyLoadedLevelType != LEVEL_Indoor) {
-                        v18b = PID_ID(pickedObject) >> 6;
+                        v18b = PID_ID(pickedObject.object_pid) >> 6;
                         short triggeredId = pOutdoor->pBModels[v18b].pFaces[pickedObjectID & 0x3F].sCogTriggeredID;
                         if (triggeredId != 0) {
                             newString = GetEventHintString(
@@ -1384,8 +1381,8 @@ void GameUI_WritePointedObjectStatusString() {
                 bForceDrawFooter = 1;
                 uLastPointedObjectID = 0;
                 return;
-            } else if (PID_TYPE(pickedObject) == OBJECT_Actor) {
-                if (pickedObject >= 0x2000000) {
+            } else if (PID_TYPE(pickedObject.object_pid) == OBJECT_Actor) {
+                if (pickedObject.depth >= 0x200u) {
                     pMouse->uPointingObjectID = 0;
                     if (uLastPointedObjectID != 0) {
                         game_ui_status_bar_string.clear();

--- a/GUI/UI/UIPopup.cpp
+++ b/GUI/UI/UIPopup.cpp
@@ -1607,7 +1607,7 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                 // if ( render->pRenderD3D )
 
                 auto vis = EngineIoc::ResolveVis();
-                v5 = vis->get_picked_object_zbuf_val();
+                v5 = vis->get_picked_object_zbuf_val().object_pid;
                 /*else
                 v5 = render->pActiveZBuffer[pX + pSRZBufferLineOffsets[pY]];*/
                 if (PID_TYPE(v5) == OBJECT_Actor) {
@@ -1618,9 +1618,9 @@ void UI_OnMouseRightClick(int mouse_x, int mouse_y) {
                 }
                 if (PID_TYPE(v5) == OBJECT_Item) {
                     if (!(pObjectList
-                              ->pObjects[pSpriteObjects[PID_ID((unsigned __int16)v5)].uObjectDescID].uFlags & 0x10)) {
+                              ->pObjects[pSpriteObjects[PID_ID(v5)].uObjectDescID].uFlags & 0x10)) {
                         GameUI_DrawItemInfo(
-                            &pSpriteObjects[PID_ID((unsigned __int16)v5)].containing_item);
+                            &pSpriteObjects[PID_ID(v5)].containing_item);
                     }
                 }
             }

--- a/GUI/UI/UITransition.cpp
+++ b/GUI/UI/UITransition.cpp
@@ -214,7 +214,7 @@ GUIWindow_Travel::GUIWindow_Travel()
     prev_screen_type = current_screen_type;
     current_screen_type = CURRENT_SCREEN::SCREEN_CHANGE_LOCATION;
     pBtn_ExitCancel = CreateButton(
-        566, 445, 75, 33, 1, 0, UIMSG_CHANGE_LOCATION_ClickCencelBtn, 0, 'N',
+        566, 445, 75, 33, 1, 0, UIMSG_CHANGE_LOCATION_ClickCancelBtn, 0, 'N',
         localization->GetString(156),
         {{ui_buttdesc2}});  // Stay in this area / Остаться в этой области
     pBtn_YES = CreateButton(486, 445, 75, 33, 1, 0, UIMSG_OnTravelByFoot, 0,

--- a/IO/Mouse.cpp
+++ b/IO/Mouse.cpp
@@ -316,14 +316,14 @@ void Mouse::UI_OnMouseLeftClick() {
         return;
     }
 
-    int picked_object = EngineIoc::ResolveVis()->get_picked_object_zbuf_val();
+    Vis_PIDAndDepth picked_object = EngineIoc::ResolveVis()->get_picked_object_zbuf_val();
 
-    ObjectType type = PID_TYPE(picked_object);
-    if (type == OBJECT_Actor && uActiveCharacter && picked_object < 0x2000000 &&
+    ObjectType type = PID_TYPE(picked_object.object_pid);
+    if (type == OBJECT_Actor && uActiveCharacter && picked_object.depth < 0x200 &&
         pPlayers[uActiveCharacter]->CanAct() &&
         pPlayers[uActiveCharacter]->CanSteal()) {
         pMessageQueue_50CBD0->AddGUIMessage(UIMSG_STEALFROMACTOR,
-                                            PID_ID(picked_object), 0);
+                                            PID_ID(picked_object.object_pid), 0);
 
         if (pParty->bTurnBasedModeOn) {
             if (pTurnEngine->turn_stage == TE_MOVEMENT) {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -1619,7 +1619,7 @@ void Game::EventLoop() {
                 case UIMSG_STEALFROMACTOR:
                     if (!uActiveCharacter) continue;
                     if (!pParty->bTurnBasedModeOn) {
-                        if (pActors[uMessageParam].uAIState == 5)
+                        if (pActors[uMessageParam].uAIState == AIState::Dead)
                             pActors[uMessageParam].LootActor();
                         else
                             Actor::StealFrom(uMessageParam);
@@ -1629,7 +1629,7 @@ void Game::EventLoop() {
                         pTurnEngine->turn_stage == TE_MOVEMENT)
                         continue;
                     if (!(pTurnEngine->field_18 & TE_HAVE_PENDING_ACTIONS)) {
-                        if (pActors[uMessageParam].uAIState == 5)
+                        if (pActors[uMessageParam].uAIState == AIState::Dead)
                             pActors[uMessageParam].LootActor();
                         else
                             Actor::StealFrom(uMessageParam);
@@ -2700,7 +2700,7 @@ void Game::OnPressSpace() {
     engine->PickKeyboard(Keyboard::IsKeyBeingHeld(VK_CONTROL), &vis_sprite_filter_3, &vis_door_filter);
     int pid = vis->get_picked_object_zbuf_val();
     if (pid != -1)
-        DoInteractionWithTopmostZObject(pid & 0xFFFF, PID_ID(pid));
+        DoInteractionWithTopmostZObject(pid & 0xFFFF);
 }
 
 void Game::GameLoop() {

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -359,7 +359,7 @@ void Game::EventLoop() {
     // int v77;                    // eax@537
     Player *pPlayer2;           // ecx@549
                                 // signed int v81; // eax@552
-    signed int v83;             // ecx@554
+    Vis_PIDAndDepth v83;             // ecx@554
     signed int v84;             // ecx@554
     GUIButton *pButton;         // eax@578
     unsigned int v86;           // eax@583
@@ -1070,7 +1070,7 @@ void Game::EventLoop() {
                     }
                     viewparams->bRedrawGameUI = 1;
                     continue;
-                case UIMSG_CHANGE_LOCATION_ClickCencelBtn:
+                case UIMSG_CHANGE_LOCATION_ClickCancelBtn:
                     CloseWindowBackground();
                     if (pParty->vPosition.x < -22528)
                         pParty->vPosition.x = -22528;
@@ -1085,7 +1085,7 @@ void Game::EventLoop() {
                     viewparams->bRedrawGameUI = true;
                     continue;
                 case UIMSG_CastSpell_Telekinesis:
-                    HEXRAYS_LOWORD(v42) = vis->get_picked_object_zbuf_val();
+                    HEXRAYS_LOWORD(v42) = vis->get_picked_object_zbuf_val().object_pid;
                     v44 = (unsigned __int16)v42;
                     v45 = PID_TYPE(v44);
                     uNumSeconds = v44;
@@ -1584,8 +1584,8 @@ void Game::EventLoop() {
                 case UIMSG_CastSpell_Shoot_Monster:  // FireBlow, Lightning, Ice
                                                      // Lightning, Swarm,
                     v83 = vis->get_picked_object_zbuf_val();
-                    v44 = (unsigned __int16)v83;
-                    v84 = v83 >> 16;
+                    v44 = v83.object_pid;
+                    v84 = v83.depth;
                     if (PID_TYPE(v44) != 3 || v84 >= 5120) continue;
                     pSpellInfo = (CastSpellInfo *)pGUIWindow_CastTargetedSpell->ptr_1C;
                     if (uMessage == UIMSG_CastSpell_Shoot_Monster) {
@@ -2272,7 +2272,7 @@ void Game::EventLoop() {
                     continue;
                 case UIMSG_F:  // what event?
                     __debugbreak();
-                    pButton2 = (GUIButton *)(unsigned __int16)vis->get_picked_object_zbuf_val();
+                    pButton2 = (GUIButton *)(unsigned __int16)vis->get_picked_object_zbuf_val().object_pid;
                     __debugbreak();  // GUIWindow::Create(0, 0, 0, 0, WINDOW_F, (int)pButton2, 0);
                     continue;
                 case UIMSG_54:  // what event?
@@ -2698,9 +2698,9 @@ void Game::EventLoop() {
 //----- (0046A14B) --------------------------------------------------------
 void Game::OnPressSpace() {
     engine->PickKeyboard(Keyboard::IsKeyBeingHeld(VK_CONTROL), &vis_sprite_filter_3, &vis_door_filter);
-    int pid = vis->get_picked_object_zbuf_val();
+    int pid = vis->get_picked_object_zbuf_val().object_pid;
     if (pid != -1)
-        DoInteractionWithTopmostZObject(pid & 0xFFFF);
+        DoInteractionWithTopmostZObject(pid);
 }
 
 void Game::GameLoop() {


### PR DESCRIPTION
Fixes #111, not being able to interact with doors properly outdoors, due to the wrong flag being set in OutdoorLocation::Load when reading the .ddm file.

There's a bunch of other refactorings involved, mostly autogenerated variable names and magic numbers being replaced with better-named variables.