### PR TITLE
fix Indoor::Load and SaveGame to use Actor_MM7

### DIFF
--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1054,8 +1054,18 @@ bool IndoorLocation::Load(const String &filename, int num_days_played,
     pGameLoadingUI_ProgressBar->Progress();
 
     memcpy(&uNumActors, pData, 4);
-    memcpy(&pActors, pData + 4, uNumActors * sizeof(Actor));
-    pData += 4 + uNumActors * sizeof(Actor);
+
+    // memcpy(&pActors, pData + 4, uNumActors * sizeof(Actor));
+    // pData += 4 + uNumActors * sizeof(Actor);
+    Actor_MM7 *tmp_actor = (Actor_MM7 *)malloc(sizeof(Actor_MM7));
+
+    for (int i = 0; i < uNumActors; ++i) {
+        memcpy(tmp_actor, pData + 4 + i * sizeof(Actor_MM7), sizeof(Actor_MM7));
+        tmp_actor->Deserialize(&pActors[i]);
+    }
+    free(tmp_actor);
+
+    pData += 4 + uNumActors * sizeof(Actor_MM7);
 
     pGameLoadingUI_ProgressBar->Progress();
     pGameLoadingUI_ProgressBar->Progress();

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -3711,8 +3711,7 @@ void Actor::Arena_summon_actor(int monster_id, __int16 x, int y, int z) {
                pMonsterStats->pInfos[monster_id].pName);
         pActors[uNumActors].sCurrentHP =
             (short)pMonsterStats->pInfos[monster_id].uHP;
-        memcpy(&pActors[uNumActors].pMonsterInfo,
-               &pMonsterStats->pInfos[monster_id], 0x58u);
+        memcpy(&pActors[uNumActors].pMonsterInfo, &pMonsterStats->pInfos[monster_id], sizeof(MonsterInfo));
         pActors[uNumActors].word_000086_some_monster_id = monster_id;
         pActors[uNumActors].uActorRadius =
             pMonsterList->pMonsters[monster_id - 1].uMonsterRadius;

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -414,8 +414,18 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
 
             memcpy(data_write_pos, &uNumActors, 4);
             data_write_pos += 4;
-            memcpy(data_write_pos, &pActors, uNumActors * sizeof(Actor));
-            data_write_pos += uNumActors * sizeof(Actor);
+
+            // memcpy(data_write_pos, &pActors, uNumActors * sizeof(Actor));
+            // data_write_pos += uNumActors * sizeof(Actor);
+            Actor_MM7 *tmp_actor = (Actor_MM7 *)malloc(sizeof(Actor_MM7));
+
+            for (int i = 0; i < uNumActors; ++i) {
+                tmp_actor->Serialize(&pActors[i]);
+                memcpy(data_write_pos + i * sizeof(Actor_MM7), tmp_actor, sizeof(Actor_MM7));
+            }
+            free(tmp_actor);
+            data_write_pos += uNumActors * sizeof(Actor_MM7);
+
             memcpy(data_write_pos, &uNumSpriteObjects, 4);
             data_write_pos += 4;
             memcpy(data_write_pos, pSpriteObjects.data(), 112 * uNumSpriteObjects);
@@ -458,8 +468,18 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
             }
             memcpy(data_write_pos, &uNumActors, 4);
             data_write_pos += 4;
-            memcpy(data_write_pos, &pActors, uNumActors * sizeof(Actor));
-            data_write_pos += uNumActors * sizeof(Actor);
+
+            // memcpy(data_write_pos, &pActors, uNumActors * sizeof(Actor));
+            // data_write_pos += uNumActors * sizeof(Actor);
+            Actor_MM7 *tmp_actor = (Actor_MM7 *)malloc(sizeof(Actor_MM7));
+
+            for (int i = 0; i < uNumActors; ++i) {
+                tmp_actor->Serialize(&pActors[i]);
+                memcpy(data_write_pos + i * sizeof(Actor_MM7), tmp_actor, sizeof(Actor_MM7));
+            }
+            free(tmp_actor);
+            data_write_pos += uNumActors * sizeof(Actor_MM7);
+
             memcpy(data_write_pos, &uNumSpriteObjects, 4);
             data_write_pos += 4;
             memcpy(data_write_pos, &pSpriteObjects,


### PR DESCRIPTION
fix Indoor::Load and SaveGame to use Actor_MM7
sizeof(MonsterInfo)