### PR TITLE
Various cleanups

### DIFF
--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -192,7 +192,8 @@ void Engine::Draw() {
             pParty->sRotationX != pParty->sPrevRotationX ||
             pParty->vPosition.z != pParty->vPrevPosition.z ||
             pParty->sEyelevel != pParty->sPrevEyelevel)
-            pParty->uFlags |= 2u;
+            pParty->uFlags |= PARTY_FLAGS_1_0002;
+
         pParty->vPrevPosition.x = pParty->vPosition.x;
         pParty->vPrevPosition.y = pParty->vPosition.y;
         pParty->vPrevPosition.z = pParty->vPosition.z;
@@ -247,7 +248,7 @@ void Engine::Draw() {
     mouse->Activate();
     render->EndScene();
     render->Present();
-    pParty->uFlags &= ~2;
+    pParty->uFlags &= ~PARTY_FLAGS_1_0002;
 }
 
 void Engine::DrawGUI() {
@@ -789,7 +790,7 @@ void PrepareWorld(unsigned int _0_box_loading_1_fullscreen) {
 
     pEventTimer->Pause();
     pMiscTimer->Pause();
-    pParty->uFlags = 2;
+    pParty->uFlags = PARTY_FLAGS_1_0002;
     CastSpellInfoHelpers::Cancel_Spell_Cast_In_Progress();
     engine->ResetCursor_Palettes_LODs_Level_Audio_SFT_Windows();
     DoPrepareWorld(0, (_0_box_loading_1_fullscreen == 0) + 1);
@@ -1285,8 +1286,7 @@ void MM7Initialization() {
     } else {
         viewparams->field_20 &= 0xFFFFFF00;
     }
-
-    pParty->uFlags |= 2;
+    pParty->uFlags |= PARTY_FLAGS_1_0002;
     viewparams->uSomeY = viewparams->uScreen_topL_Y;
     viewparams->uSomeX = viewparams->uScreen_topL_X;
     viewparams->uSomeZ = viewparams->uScreen_BttmR_X;
@@ -1364,7 +1364,7 @@ void Engine::_461103_load_level_sub() {
 
     GenerateItemsInChest();
     pGameLoadingUI_ProgressBar->Progress();
-    pParty->uFlags |= 2;
+    pParty->uFlags |= PARTY_FLAGS_1_0002;
     pParty->field_7B5_in_arena_quest = 0;
     dword_5C6DF8 = 1;
     pNPCStats->uNewlNPCBufPos = 0;
@@ -1533,7 +1533,7 @@ void sub_44861E_set_texture(unsigned int uFaceCog, const char *pFilename) {
                 sub_44861E_set_texture_outdoor(uFaceCog, pFilename);
             }
 
-            pParty->uFlags |= 2;
+            pParty->uFlags |= PARTY_FLAGS_1_0002;
         }
     }
 }
@@ -1552,7 +1552,7 @@ void sub_44892E_set_faces_bit(int sCogNumber, int bit, int on) {
                             .uAttributes &= ~bit;
                 }
             }
-            pParty->uFlags |= 2;
+            pParty->uFlags |= PARTY_FLAGS_1_0002;
         } else {
             for (BSPModel &model : pOutdoor->pBModels) {
                 for (ODMFace &face : model.pFaces) {
@@ -1566,7 +1566,7 @@ void sub_44892E_set_faces_bit(int sCogNumber, int bit, int on) {
                 }
             }
         }
-        pParty->uFlags |= 2;
+        pParty->uFlags |= PARTY_FLAGS_1_0002;
     }
 }
 
@@ -1584,7 +1584,7 @@ void SetDecorationSprite(uint16_t uCog, bool bHide, const char *pFileName) {
             else
                 pLevelDecorations[i].uFlags |= LEVEL_DECORATION_INVISIBLE;
 
-            pParty->uFlags |= 2;
+            pParty->uFlags |= PARTY_FLAGS_1_0002;
         }
     }
 }
@@ -1680,7 +1680,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
     }
 
     // water damage
-    if (pParty->uFlags & 4 &&
+    if (pParty->uFlags & PARTY_FLAGS_1_WATER_DAMAGE &&
         pParty->_6FC_water_lava_timer < pParty->GetPlayingTime().value) {
         pParty->_6FC_water_lava_timer = pParty->GetPlayingTime().value + 128;
         viewparams->bRedrawGameUI = true;
@@ -1695,7 +1695,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
                     pPlayers[pl]->ReceiveDamage(
                         (int64_t)pPlayers[pl]->GetMaxHealth() * 0.1,
                         DMGT_FIRE);
-                    if (pParty->uFlags & 4) {
+                    if (pParty->uFlags & PARTY_FLAGS_1_WATER_DAMAGE) {
                         GameUI_StatusBar_OnEvent_128ms(
                             localization->GetString(660));  // You're drowning!
                     }
@@ -1707,7 +1707,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
     }
 
     // lava damage
-    if (pParty->uFlags & 0x200 &&
+    if (pParty->uFlags & PARTY_FLAGS_1_BURNING &&
         pParty->_6FC_water_lava_timer < pParty->GetPlayingTime().value) {
         viewparams->bRedrawGameUI = true;
         pParty->_6FC_water_lava_timer = pParty->GetPlayingTime().value + 128;
@@ -1715,7 +1715,7 @@ void _494035_timed_effects__water_walking_damage__etc() {
         for (uint pl = 1; pl <= 4; pl++) {
             pPlayers[pl]->ReceiveDamage(
                 (signed __int64)pPlayers[pl]->GetMaxHealth() * 0.1, DMGT_FIRE);
-            if (pParty->uFlags & 0x200) {
+            if (pParty->uFlags & PARTY_FLAGS_1_BURNING) {
                 GameUI_StatusBar_OnEvent_128ms(
                     localization->GetString(661));  // On fire!
             }

--- a/Engine/Events.cpp
+++ b/Engine/Events.cpp
@@ -493,7 +493,7 @@ LABEL_47:
                         if (pEventID == 78) {
                             HouseDialogPressCloseBtn();
                             window_SpeakInHouse->Release();
-                            pParty->uFlags &= ~2;
+                            pParty->uFlags &= ~PARTY_FLAGS_1_0002;
                             if (EnterHouse(HOUSE_DARK_GUILD_PIT)) {
                                 pAudioPlayer->StopChannels(-1, -1);
                                 window_SpeakInHouse = new GUIWindow_House(
@@ -588,7 +588,7 @@ LABEL_47:
                             HouseDialogPressCloseBtn();
                             pMediaPlayer->Unload();
                             window_SpeakInHouse->Release();
-                            pParty->uFlags &= ~2;
+                            pParty->uFlags &= ~PARTY_FLAGS_1_0002;
                             activeLevelDecoration = (LevelDecoration *)1;
                             if (EnterHouse(HOUSE_BODY_GUILD_ERATHIA)) {
                                 pAudioPlayer->PlaySound(SOUND_Invalid, 0, 0, -1, 0, 0);

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -1385,7 +1385,7 @@ bool Render::InitializeFullscreen() {
     pBeforePresentFunction = Present_NoColorKey;
 
     bWindowMode = 0;
-    pParty->uFlags |= 2;
+    pParty->uFlags |= PARTY_FLAGS_1_0002;
     pViewport->SetFOV(_6BE3A0_fov);
 
     return true;

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -385,7 +385,7 @@ void IndoorLocation::Draw() {
     render->DrawBillboardList_BLV();
     //}
 
-    pParty->uFlags &= ~2;
+    pParty->uFlags &= ~PARTY_FLAGS_1_0002;
     engine->DrawParticles();
     trail_particle_generator.UpdateParticles();
 }
@@ -722,7 +722,7 @@ void IndoorLocation::ToggleLight(signed int sLightID, unsigned int bToggle) {
             pIndoor->pLights[sLightID].uAtributes &= 0xFFFFFFF7;
         else
             pIndoor->pLights[sLightID].uAtributes |= 8;
-        pParty->uFlags |= 2;
+        pParty->uFlags |= PARTY_FLAGS_1_0002;
     }
 }
 
@@ -990,7 +990,7 @@ bool IndoorLocation::Load(const String &filename, int num_days_played,
         }
     }
 
-    if (dword_6BE364_game_settings_1 & GAME_SETTINGS_2000) {
+    if (dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN) {
         respawn_interval_days = 0x1BAF800;
     }
 
@@ -2226,11 +2226,11 @@ void PrepareToLoadBLV(unsigned int bLoading) {
 
     if (v4 == 2) Error("Attempt to open new level before clearing old");
     if (v4 == 3) Error("Out of memory loading indoor level");
-    if (!(dword_6BE364_game_settings_1 & GAME_SETTINGS_2000)) {
+    if (!(dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)) {
         Actor::InitializeActors();
         SpriteObject::InitializeSpriteObjects();
     }
-    dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_2000;
+    dword_6BE364_game_settings_1 &= ~GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN;
     if (!map_id) pDest = 0;
     if (pDest == 1) {
         for (uint i = 0; i < pIndoor->uNumSpawnPoints; ++i) {

--- a/Engine/Graphics/Outdoor.cpp
+++ b/Engine/Graphics/Outdoor.cpp
@@ -245,7 +245,7 @@ int OutdoorLocation::GetHeightOnTerrain(int sX, int sZ) {
 
 //----- (00488F5C) --------------------------------------------------------
 bool OutdoorLocation::Initialize(const String &filename, int days_played,
-                                 int respawn_interval_days, 
+                                 int respawn_interval_days,
                                  bool *outdoors_was_respawned) {
     decal_builder->Reset(0);
 
@@ -981,7 +981,7 @@ void OutdoorLocation::Release() {
 }
 
 bool OutdoorLocation::Load(const String &filename, int days_played,
-                           int respawn_interval_days, 
+                           int respawn_interval_days,
                            bool *outdoors_was_respawned) {
     if (engine->IsUnderwater()) {
         pPaletteManager->pPalette_tintColor[0] = 0x10;
@@ -1130,7 +1130,7 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
     assert(sizeof(SpawnPointMM7) == 24);
     uint spawnPointsSize = uNumSpawnPoints * sizeof(SpawnPointMM7);
     pSpawnPoints = (SpawnPointMM7 *)malloc(spawnPointsSize);
-    
+
     memcpy(pSpawnPoints, pSrc + 4, spawnPointsSize);
     pSrc += 4 + spawnPointsSize;
 
@@ -1157,7 +1157,7 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
 
     //  The ddm.uNumX values are only written in SaveLoad::Save, and
     //  only used for this check. Is it for forwards compatibility?
-    bool object_count_in_level_changed_since_save = 
+    bool object_count_in_level_changed_since_save =
         ddm.uNumFacesInBModels &&
         ddm.uNumBModels &&
         ddm.uNumDecorations &&
@@ -1168,7 +1168,7 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
     if (dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)
         respawn_interval_days = 0x1BAF800;
 
-    bool should_respawn = 
+    bool should_respawn =
         days_played - ddm.uLastRepawnDay >= respawn_interval_days ||
         !ddm.uLastRepawnDay;
 
@@ -1187,7 +1187,7 @@ bool OutdoorLocation::Load(const String &filename, int days_played,
         free(pSrcMem);
 
         ddm.uLastRepawnDay = days_played;
-        if (!object_count_in_level_changed_since_save) 
+        if (!object_count_in_level_changed_since_save)
             ++ddm.uNumRespawns;
 
         *outdoors_was_respawned = true;
@@ -2698,11 +2698,10 @@ void ODM_ProcessPartyActions() {
 
             case PARTY_Jump:  // прыжок
                 if ((!partyAtHighSlope || bmodel_standing_on_pid) &&
-                    !hovering && 
-                    pParty->field_24 && 
-                    !(pParty->uFlags & PARTY_FLAGS_1_WATER_DAMAGE) && 
+                    !hovering &&
+                    pParty->field_24 &&
+                    !(pParty->uFlags & PARTY_FLAGS_1_WATER_DAMAGE) &&
                     !(pParty->uFlags & PARTY_FLAGS_1_BURNING)) {
-
                     hovering = true;
                     fall_speed += pParty->field_24 * 96;
                 }
@@ -3802,9 +3801,9 @@ void ODM_LoadAndInitialize(const String &pFilename, ODMRenderParams *thisa) {
     day_attrib &= ~DAY_ATTRIB_FOG;
     dword_6BE13C_uCurrentlyLoadedLocationID = map_id;
     bool outdoor_was_respawned;
-    pOutdoor->Initialize(pFilename, pParty->GetPlayingTime().GetDays() + 1, 
+    pOutdoor->Initialize(pFilename, pParty->GetPlayingTime().GetDays() + 1,
         respawn_interval, &outdoor_was_respawned);
-    
+
     if (!(dword_6BE364_game_settings_1 & GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN)) {
         Actor::InitializeActors();
         SpriteObject::InitializeSpriteObjects();

--- a/Engine/Graphics/Outdoor.h
+++ b/Engine/Graphics/Outdoor.h
@@ -95,7 +95,7 @@ struct OutdoorLocation {
     TileDesc *DoGetTile(int uX, int uZ);
     int GetHeightOnTerrain(int sX, int sZ);
     bool Initialize(const String &filename, int days_played,
-                    int respawn_interval_days, 
+                    int respawn_interval_days,
                     bool * outdoors_was_respawned);
     // bool Release2();
     bool GetTravelDestination(signed int sPartyX, signed int sPartyZ,

--- a/Engine/Graphics/Outdoor.h
+++ b/Engine/Graphics/Outdoor.h
@@ -74,7 +74,7 @@ struct OutdoorLocation {
     void CreateDebugLocation();
     void Release();
     bool Load(const String &filename, int days_played,
-              int respawn_interval_days, int *thisa);
+              int respawn_interval_days, bool *outdoors_was_respawned);
     int GetTileIdByTileMapId(signed int a2);
     int _47ED83(signed int a2, signed int a3);
     int ActuallyGetSomeOtherTileInfo(signed int uX, signed int uY);
@@ -95,7 +95,8 @@ struct OutdoorLocation {
     TileDesc *DoGetTile(int uX, int uZ);
     int GetHeightOnTerrain(int sX, int sZ);
     bool Initialize(const String &filename, int days_played,
-                    int respawn_interval_days, int *thisa);
+                    int respawn_interval_days, 
+                    bool * outdoors_was_respawned);
     // bool Release2();
     bool GetTravelDestination(signed int sPartyX, signed int sPartyZ,
                               char *pOut, signed int a5);

--- a/Engine/Graphics/Viewport.cpp
+++ b/Engine/Graphics/Viewport.cpp
@@ -257,7 +257,7 @@ bool ActorInteraction(unsigned int id) {
             if (pNPCStats->pGroups_copy[pActors[id].uGroup]) {
                 if (pNPCStats->pCatchPhrases
                         [pNPCStats->pGroups_copy[pActors[id].uGroup]]) {
-                    pParty->uFlags |= 2;
+                    pParty->uFlags |= PARTY_FLAGS_1_0002;
                     branchless_dialogue_str = pNPCStats->pCatchPhrases[pNPCStats->pGroups_copy[pActors[id].uGroup]];
                     sub_4451A8_press_any_key(0, 0, 0);
                 }

--- a/Engine/MapInfo.cpp
+++ b/Engine/MapInfo.cpp
@@ -234,7 +234,7 @@ MAP_TYPE MapStats::GetMapInfo(const String &Str2) {
     }
 
     Error("Map not found!");
-    return (MAP_TYPE)-1;
+    return (MAP_TYPE)-1; // @TODO: This should be MAP_INVALID!, as it's if'ed later.
 }
 
 int MapInfo::SpawnRandomTreasure(SpawnPointMM7 *a2) {

--- a/Engine/MapInfo.cpp
+++ b/Engine/MapInfo.cpp
@@ -234,7 +234,7 @@ MAP_TYPE MapStats::GetMapInfo(const String &Str2) {
     }
 
     Error("Map not found!");
-    return (MAP_TYPE)-1; // @TODO: This should be MAP_INVALID!, as it's if'ed later.
+    return (MAP_TYPE)-1;  // @TODO: This should be MAP_INVALID!, as it's if'ed later.
 }
 
 int MapInfo::SpawnRandomTreasure(SpawnPointMM7 *a2) {

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -2798,7 +2798,7 @@ void Actor::UpdateActorAI() {
             else if (pParty->sRotationX < -128)
                 pParty->sRotationX = -128;
 
-            pParty->uFlags |= 2u;
+            pParty->uFlags |= PARTY_FLAGS_1_0002;
             pParty->armageddon_timer -= pMiscTimer->uTimeElapsed;
             v4 = pParty->armageddonDamage + 50;
             if (pParty->armageddon_timer <= 0) {
@@ -4594,9 +4594,9 @@ int Actor::MakeActorAIList_BLV() {
             pActors[i].ResetHostile();  // ~0x01000000
             if (pActors[i].ActorEnemy() || pActors[i].GetActorsRelation(0)) {
                 pActors[i].uAttributes |= ACTOR_HOSTILE;
-                if (!(pParty->uFlags & 0x10) && (double)distance < 307.2)
+                if (!(pParty->GetRedAlert()) && (double)distance < 307.2)
                     pParty->SetRedAlert();
-                if (!(pParty->uFlags & 0x20) && distance < 5120)
+                if (!(pParty->GetYellowAlert()) && distance < 5120)
                     pParty->SetYellowAlert();
             }
             ai_near_actors_distances[v45] = distance;

--- a/Engine/Objects/Player.h
+++ b/Engine/Objects/Player.h
@@ -90,7 +90,7 @@ enum PlayerSpeech {
     SPEECH_44 = 44,
     SPEECH_45 = 45,
     SPEECH_46 = 46,
-    SPEECH_47 = 47, // Let's get out of here! (Plays when leaving an area when the party alert is red or yellow)
+    SPEECH_47 = 47,  // Let's get out of here! (Plays when leaving an area when the party alert is red or yellow)
     SPEECH_48 = 48,
     SPEECH_49 = 49,
     SPEECH_50 = 50,

--- a/Engine/Objects/Player.h
+++ b/Engine/Objects/Player.h
@@ -90,7 +90,7 @@ enum PlayerSpeech {
     SPEECH_44 = 44,
     SPEECH_45 = 45,
     SPEECH_46 = 46,
-    SPEECH_47 = 47,
+    SPEECH_47 = 47, // Let's get out of here! (Plays when leaving an area when the party alert is red or yellow)
     SPEECH_48 = 48,
     SPEECH_49 = 49,
     SPEECH_50 = 50,
@@ -217,7 +217,7 @@ enum PLAYER_CLASS_TYPE : unsigned __int8 {
     PLAYER_CLASS_CHEVALIER = 1,
     PLAYER_CLASS_CHAMPION = 2,
     PLAYER_CLASS_BLACK_KNIGHT = 3,
-    PLAYER_CLASS_THEIF = 4,
+    PLAYER_CLASS_THIEF = 4,
     PLAYER_CLASS_ROGUE = 5,
     PLAYER_CLASS_SPY = 6,
     PLAYER_CLASS_ASSASSIN = 7,

--- a/Engine/Party.cpp
+++ b/Engine/Party.cpp
@@ -544,7 +544,7 @@ void Party::Reset() {
     pPlayers[0].RandomizeName();
     strcpy(pPlayers[0].pName, localization->GetString(509));
 
-    pPlayers[1].Reset(PLAYER_CLASS_THEIF);
+    pPlayers[1].Reset(PLAYER_CLASS_THIEF);
     pPlayers[1].uCurrentFace = 3;
     pPlayers[1].uPrevVoiceID = 3;
     pPlayers[1].uVoiceID = 3;

--- a/Engine/Party.h
+++ b/Engine/Party.h
@@ -53,7 +53,7 @@ enum PARTY_QUEST_BITS : uint16_t {
 
 /*  355 */
 enum PARTY_FLAGS_1 : int32_t {
-    // Flag 0x2 is set or unset in a ton of places, only used in 
+    // Flag 0x2 is set or unset in a ton of places, only used in
     // OutdoorLocation::Draw and UIDialogue::sub_4451A8_press_any_key
     PARTY_FLAGS_1_0002 = 0x0002,
     PARTY_FLAGS_1_WATER_DAMAGE = 0x0004,

--- a/Engine/Party.h
+++ b/Engine/Party.h
@@ -53,14 +53,17 @@ enum PARTY_QUEST_BITS : uint16_t {
 
 /*  355 */
 enum PARTY_FLAGS_1 : int32_t {
+    // Flag 0x2 is set or unset in a ton of places, only used in 
+    // OutdoorLocation::Draw and UIDialogue::sub_4451A8_press_any_key
     PARTY_FLAGS_1_0002 = 0x0002,
     PARTY_FLAGS_1_WATER_DAMAGE = 0x0004,
     PARTY_FLAGS_1_FALLING = 0x0008,
     PARTY_FLAGS_1_ALERT_RED = 0x0010,
     PARTY_FLAGS_1_ALERT_YELLOW = 0x0020,
+    PARTY_FLAGS_1_ALERT_RED_OR_YELLOW = 0x0030,
     PARTY_FLAGS_1_STANDING_ON_WATER = 0x0080,
     PARTY_FLAGS_1_LANDING = 0x0100,
-    PARTY_FLAGS_1_BURNING = 0x200
+    PARTY_FLAGS_1_BURNING = 0x0200
 };
 enum PARTY_FLAGS_2 : int32_t {
     PARTY_FLAGS_2_RUNNING = 0x2,
@@ -226,6 +229,10 @@ struct Party {
         return (uFlags & PARTY_FLAGS_1_ALERT_YELLOW) != 0;
     }
     inline void SetYellowAlert() { uFlags |= PARTY_FLAGS_1_ALERT_YELLOW; }
+
+    inline bool GetRedOrYellowAlert() {
+        return (uFlags & PARTY_FLAGS_1_ALERT_RED_OR_YELLOW) != 0;
+    }
 
     GameTime &GetPlayingTime() { return this->playing_time; }
 

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -217,7 +217,7 @@ void LoadGame(unsigned int uSlot) {
     pCurrentMapName = header->pLocationName;
     free(header);
 
-    dword_6BE364_game_settings_1 |= GAME_SETTINGS_2000 | GAME_SETTINGS_0001;
+    dword_6BE364_game_settings_1 |= GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN | GAME_SETTINGS_0001;
 
     for (uint i = 0; i < uNumSavegameFiles; ++i) {
         if (pSavegameThumbnails[i] != nullptr) {

--- a/Engine/Serialization/LegacyImages.cpp
+++ b/Engine/Serialization/LegacyImages.cpp
@@ -831,7 +831,7 @@ void Player_Image_MM7::Deserialize(Player* player) {
         player->classType = PLAYER_CLASS_BLACK_KNIGHT;
         break;
     case 4:
-        player->classType = PLAYER_CLASS_THEIF;
+        player->classType = PLAYER_CLASS_THIEF;
         break;
     case 5:
         player->classType = PLAYER_CLASS_ROGUE;

--- a/Engine/Spells/CastSpellInfo.cpp
+++ b/Engine/Spells/CastSpellInfo.cpp
@@ -1522,7 +1522,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     break;
                 for (uint pl_id = 0; pl_id < 4; pl_id++)
                     pOtherOverlayList->_4418B1(2040, pl_id + 100, 0, 65536);
-                pParty->uFlags |= 0x100;
+                pParty->uFlags |= PARTY_FLAGS_1_LANDING;
                 pParty->uFallSpeed = 1000;
                 spell_sound_flag = true;
                 break;
@@ -1550,8 +1550,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     default:
                         assert(false);
                 }
-                if (pParty->uFlags &
-                    (PARTY_FLAGS_1_ALERT_RED | PARTY_FLAGS_1_ALERT_YELLOW)) {
+                if (pParty->GetRedOrYellowAlert()) {
                     GameUI_StatusBar_OnEvent(localization->GetString(
                         638));  // There are hostile creatures nearby!
                     pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);

--- a/Engine/mm7_data.h
+++ b/Engine/mm7_data.h
@@ -327,7 +327,7 @@ extern float flt_6BE150_look_up_down_dangle;
 extern String pCurrentMapName;
 extern unsigned int uLevelMapStatsID;
 
-#define GAME_SETTINGS_0001 0x0001
+#define GAME_SETTINGS_0001 0x0001  // Skip AI next frame due to changing levels etc.
 #define GAME_SETTINGS_INVALID_RESOLUTION 0x0002
 #define GAME_SETTINGS_NO_INTRO 0x0004
 #define GAME_SETTINGS_NO_LOGO 0x0008
@@ -340,7 +340,7 @@ extern unsigned int uLevelMapStatsID;
 #define GAME_SETTINGS_0400_MISC_TIMER 0x0400
 #define GAME_SETTINGS_0800 0x0800
 #define GAME_SETTINGS_1000 0x1000
-#define GAME_SETTINGS_2000 0x2000  // initialisation state - no respawning
+#define GAME_SETTINGS_LOADING_SAVEGAME_SKIP_RESPAWN 0x2000  // don't respawn the level we're loading because we're loading a saved game
 #define GAME_SETTINGS_4000 0x4000  // initialisation state
 extern int dword_6BE364_game_settings_1;  // GAME_SETTINGS_*
 

--- a/GUI/UI/UIDialogue.cpp
+++ b/GUI/UI/UIDialogue.cpp
@@ -614,7 +614,7 @@ void GUIWindow_GenericDialogue::Update() {
 
 void sub_4451A8_press_any_key(int a1, int a2, int a4) {
     if (!pGUIWindow2) {
-        if (pParty->uFlags & 2) {
+        if (pParty->uFlags & PARTY_FLAGS_1_0002) {
             engine->Draw();
         }
         pAudioPlayer->StopChannels(-1, -1);

--- a/GUI/UI/UIHouses.cpp
+++ b/GUI/UI/UIHouses.cpp
@@ -1856,7 +1856,7 @@ void TravelByTransport() {
                 } else {
                     pIndoorCameraD3D->sRotationY = 0;
 
-                    pParty->uFlags |= 2u;
+                    pParty->uFlags |= PARTY_FLAGS_1_0002;
                     pParty->vPosition.x = pTravel->arrival_x;
                     pParty->vPosition.y = pTravel->arrival_y;
                     pParty->vPosition.z = pTravel->arrival_z;
@@ -4412,7 +4412,7 @@ void GUIWindow_House::Release() {
         pParty->sRotationY = (stru_5C6E00->uIntegerDoublePi - 1) & (stru_5C6E00->uIntegerPi + pParty->sRotationY);
         pIndoorCameraD3D->sRotationY = pParty->sRotationY;
     }
-    pParty->uFlags |= 2u;
+    pParty->uFlags |= PARTY_FLAGS_1_0002;
 
     GUIWindow::Release();
 }

--- a/GUI/UI/UIPartyCreation.cpp
+++ b/GUI/UI/UIPartyCreation.cpp
@@ -635,7 +635,7 @@ void GUIWindow_PartyCreation::Update() {
         localization->GetClassName(8), 0, 0, 0);
 
     pColorText = Color16(0, 0xF7, 0xF7);
-    if (uClassType != PLAYER_CLASS_THEIF)
+    if (uClassType != PLAYER_CLASS_THIEF)
         pColorText = Color16(0xFF, 0xFF, 0xFF);
     pTextCenter =
         pFontCreate->AlignText_Center(65, localization->GetClassName(4));

--- a/GUI/UI/UITransition.cpp
+++ b/GUI/UI/UITransition.cpp
@@ -117,7 +117,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
                          .pName.c_str());  // Enter %s   Войти в ^Pv[%s]
 
             if (uCurrentlyLoadedLevelType == LEVEL_Indoor && uActiveCharacter &&
-                pParty->uFlags & 0x30)
+                pParty->GetRedOrYellowAlert())
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_47, 0);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation =
@@ -130,7 +130,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
                       // )
                       //  PlayHouseSound(anim_id, HouseSound_Greeting);
             if (uCurrentlyLoadedLevelType == LEVEL_Indoor && uActiveCharacter &&
-                pParty->uFlags & 0x30)
+                pParty->GetRedOrYellowAlert())
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_47, 0);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation =
@@ -146,7 +146,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
                               // pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId
                               // ) PlayHouseSound(anim_id, HouseSound_Greeting);
             if (uCurrentlyLoadedLevelType == LEVEL_Indoor && uActiveCharacter &&
-                pParty->uFlags & 0x30)
+                pParty->GetRedOrYellowAlert())
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_47, 0);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation =
@@ -156,7 +156,7 @@ GUIWindow_Transition::GUIWindow_Transition(uint anim_id, uint exit_pic_id,
             // if ( pAnimatedRooms[p2DEvents[anim_id].uAnimationID].uRoomSoundId
             // ) PlayHouseSound(anim_id, HouseSound_Greeting);
             if (uCurrentlyLoadedLevelType == LEVEL_Indoor && uActiveCharacter &&
-                pParty->uFlags & 0x30)
+                pParty->GetRedOrYellowAlert())
                 pPlayers[uActiveCharacter]->PlaySound(SPEECH_47, 0);
             if (IndoorLocation::GetLocationIndex(pLocationName))
                 uCurrentHouse_Animation =


### PR DESCRIPTION
A bunch of things I found while browsing the code that's built up, figured I'd compile it into a PR

Cleanup of OutdoorLocation::Load. 
Made all uses of pParty->uFlags referene the PARTY_FLAGS_1 enum instead of integer literals.
Gave a name to GAME_SETTINGS_2000 (LOADING_SAVEGAME_SKIP_RESPAWN).
Fixed typo in PLAYER_CLASS, it's now named THIEF instead of THEIF