### PR TITLE
Add build folder as per HACKING instructions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Build/Visual Studio 2017/Debug
 
 # cmake
 out
+build
 
 # 3d-party libs are auto-resolved by cmake
 lib

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,11 @@ Build/Visual Studio 2017/Debug
 .vscode/*
 *.code-workspace
 
-# cmake
+# CMake
+## Default output folder used by Visual Studio
 out
+
+## Output folder on Linux as described in HACKING
 build
 
 # 3d-party libs are auto-resolved by cmake


### PR DESCRIPTION
The HACKING instructions advise using the "build" folder in the root as output for CMake, but this folder is not in the Git ignore list by default, immediately resulting in large amounts of changes when setting up a new repository to start hacking away on the project.