### PR TITLE
Implement more linux platform functions

### DIFF
--- a/Media/MediaPlayer.cpp
+++ b/Media/MediaPlayer.cpp
@@ -860,7 +860,7 @@ void MPlayer::PlayFullscreenMovie(const std::string &pFilename) {
 
             render->BeginScene();
 
-            OS_Sleep(30);
+            OS_Sleep(2);
 
             PMemBuffer buffer = pMovie_Track->GetFrame();
             if (!buffer) {

--- a/Platform/Lin/Lin.cpp
+++ b/Platform/Lin/Lin.cpp
@@ -1,5 +1,6 @@
 #include "Platform/Lin/Lin.h"
 
+#include <SDL.h>
 #include <dirent.h>
 #include <fnmatch.h>
 #include <sys/time.h>
@@ -21,11 +22,11 @@ unsigned int OS_GetTime() {
 }
 
 void OS_ShowCursor(bool show) {
-    // ShowCursor(show ? 1 : 0);
+    SDL_ShowCursor(show ? SDL_ENABLE : SDL_DISABLE);
 }
 
 void OS_Sleep(int ms) {
-    // Sleep(ms);
+    SDL_Delay(ms);
 }
 
 bool OS_OpenConsole() {


### PR DESCRIPTION
This builds on (and includes) #174 to implement `OS_Sleep` and `OS_ShowCursor` on Linux. This fixes the cursor not being hidden on Linux whilst fullscreen videos are playing, and will likely also fix issues with videos playing too quickly as `OS_Sleep` could not be implemented there - although I can't test this due to #175 currently.