### PR TITLE
Fix crash when entering load/save screen

### DIFF
--- a/GUI/UI/UISaveLoad.cpp
+++ b/GUI/UI/UISaveLoad.cpp
@@ -239,7 +239,6 @@ static void UI_DrawSaveLoad(bool save) {
     unsigned int pSaveFiles;
 
     if (pSavegameUsedSlots[uLoadGameUI_SelectedSlot]) {
-        memset(&save_load_window, 0, 0x54);
         save_load_window.uFrameX = pGUIWindow_CurrentMenu->uFrameX + 240;
         save_load_window.uFrameWidth = 220;
         save_load_window.uFrameY = (pGUIWindow_CurrentMenu->uFrameY - pFontSmallnum->GetHeight()) + 157;


### PR DESCRIPTION
Simple one line change that removes a memset on the save_load_window object. This memset was corrupting the vtable of the object and causing the destructor call to crash.

Not sure of the intend behind the initial memset, perhaps some leftover debug code?