### PR TITLE
Fixed OpenGL usage on macOS, assert in audio playback, temp files creation

### DIFF
--- a/CMakeModules/CppLint.cmake
+++ b/CMakeModules/CppLint.cmake
@@ -1,8 +1,8 @@
-find_package(Python3)
+find_package(PythonInterp)
 
 set(CPPLINT_VERSION "1.5.5")
 
-if(Python3_Interpreter_FOUND AND NOT CPPLINT_FOUND)
+if(PYTHONINTERP_FOUND AND NOT CPPLINT_FOUND)
   file(DOWNLOAD "https://github.com/cpplint/cpplint/archive/refs/tags/${CPPLINT_VERSION}.tar.gz" "${CMAKE_CURRENT_BINARY_DIR}/cpplint.tar.gz")
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xz cpplint.tar.gz
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -29,9 +29,10 @@ function(target_check_style TARGET)
         endif()
     endforeach(sourcefile)
 
-    add_custom_target(${TARGET_NAME} ${Python2_EXECUTABLE} ${CPPLINT_COMMAND} ${SOURCES_LIST}
+    add_custom_target(${TARGET_NAME} ${PYTHON_EXECUTABLE} ${CPPLINT_COMMAND} ${SOURCES_LIST}
                       DEPENDS ${SOURCES_LIST}
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     add_dependencies(check_style ${TARGET_NAME})
+    set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "check_style")
   endif()
 endfunction()

--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -5,6 +5,7 @@
 #include <io.h>
 #endif
 
+#include <filesystem>
 #include <algorithm>
 
 #include "src/Application/Game.h"
@@ -138,6 +139,10 @@ std::string MakeDataPath(std::initializer_list<std::string_view> paths) {
     res = OS_casepath(res);
 
     return res;
+}
+
+std::string MakeTempPath(const char *file_rel_path) {
+    return std::filesystem::temp_directory_path().string() + OS_GetDirSeparator() + file_rel_path;
 }
 
 uint32_t Color32(uint16_t color16) {

--- a/Engine/Engine.h
+++ b/Engine/Engine.h
@@ -563,3 +563,4 @@ std::string MakeDataPath(Ts&&... paths) {
         "T must be a basic string");
     return MakeDataPath({ paths... });
 }
+std::string MakeTempPath(const char *file_rel_path);

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -439,7 +439,7 @@ bool LOD::WriteableFile::_4621A7() {  // закрыть и загрузить з
     return LoadFile(pLODName, 0);
 }
 
-int LOD::WriteableFile::FixDirectoryOffsets() {
+bool LOD::WriteableFile::FixDirectoryOffsets() {
     unsigned int total_size = 0;
     for (int i = 0; i < uNumSubDirs; i++) {
         total_size += pSubIndices[i].uDataSize;
@@ -452,7 +452,7 @@ int LOD::WriteableFile::FixDirectoryOffsets() {
         temp_offset += pSubIndices[i].uDataSize;
     }
 
-    String Filename = MakeDataPath("lod.tmp");
+    String Filename = MakeTempPath("lod.tmp");
     FILE *tmp_file = fopen(Filename.c_str(), "wb+");
     if (tmp_file == nullptr) {
         return 5;
@@ -483,14 +483,14 @@ int LOD::WriteableFile::FixDirectoryOffsets() {
 
     fclose(tmp_file);
     fclose(pOutputFileHandle);
+    pOutputFileHandle = nullptr;
     CloseWriteFile();
-    remove(MakeDataPath("lodapp.tmp").c_str());
+    remove(MakeTempPath("lodapp.tmp").c_str());
     remove(pLODName.c_str());
     rename(Filename.c_str(), pLODName.c_str());
     CloseWriteFile();
-    LoadFile(pLODName.c_str(), 0);
 
-    return 0;
+    return LoadFile(pLODName.c_str(), 0);
 }
 
 bool LOD::WriteableFile::AppendDirectory(const String &file_name, const void *pData, size_t data_size) {
@@ -510,7 +510,7 @@ int LOD::WriteableFile::CreateTempFile() {
 
     if (pIOBuffer && uIOBufferSize) {
         uNumSubDirs = 0;
-        pOutputFileHandle = fopen(MakeDataPath("lodapp.tmp").c_str(), "wb+");
+        pOutputFileHandle = fopen(MakeTempPath("lodapp.tmp").c_str(), "wb+");
         return pOutputFileHandle ? 1 : 7;
     } else {
         return 5;

--- a/Engine/LOD.h
+++ b/Engine/LOD.h
@@ -101,7 +101,7 @@ class WriteableFile : public File {
     unsigned int Write(const String &file_name, const void *pDirData, size_t size, int a4);
     void CloseWriteFile();
     int CreateTempFile();
-    int FixDirectoryOffsets();
+    bool FixDirectoryOffsets();
     bool _4621A7();
     int CreateNewLod(LOD::FileHeader *pHeader, const String &root_name, const String &Source);
 

--- a/Engine/Spells/CastSpellInfo.cpp
+++ b/Engine/Spells/CastSpellInfo.cpp
@@ -2660,7 +2660,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     } else {
                         if (item.uItemID) {
                             GameUI_SetStatusBar(StringPrintf(
-                                "(%s)", item.GetDisplayName()));
+                                "(%s)", item.GetDisplayName().c_str()));
                         } else {
                             GameUI_SetStatusBar("nothing");
                         }

--- a/Media/Audio/OpenALSoundProvider.h
+++ b/Media/Audio/OpenALSoundProvider.h
@@ -12,8 +12,6 @@
 
 #include "Media/Media.h"
 
-void log(const char *format, ...);
-
 class OpenALSoundProvider {
  public:
     struct TrackBuffer {
@@ -48,6 +46,8 @@ class OpenALSoundProvider {
     void SetOrientation(float yaw, float pitch);
 
  protected:
+    void DeleteBuffers(StreamingTrackBuffer *track, int type);
+
     ALCdevice *device;
     ALCcontext *context;
 };

--- a/Media/CMakeLists.txt
+++ b/Media/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+if(APPLE)
+  add_definitions(-DFF_API_NEXT)
+endif()
+
 set(MEDIA_SOURCES Media.cpp
                   MediaPlayer.cpp
                   Audio/AudioPlayer.cpp

--- a/Platform/OSWindow.h
+++ b/Platform/OSWindow.h
@@ -25,6 +25,7 @@ using Io::IMouseController;
 class OSWindow {
  public:
     OSWindow();
+    virtual ~OSWindow() {}
 
     virtual void SetFullscreenMode() = 0;
     virtual void SetWindowedMode(int new_window_width, int new_window_height) = 0;

--- a/Platform/Sdl2Window.h
+++ b/Platform/Sdl2Window.h
@@ -44,7 +44,6 @@ class Sdl2Window : public OSWindow {
     // Sdl2Window-specific interface follows
     void* GetWinApiHandle() override;
     SDL_Window* getSDLWindow();
-    SDL_Surface* getSDLWindowSurface();
     SDL_GLContext* getSDLOpenGlContext();
     SDL_Window* CreateSDLWindow();
     void DestroySDLWindow();
@@ -61,7 +60,7 @@ class Sdl2Window : public OSWindow {
         int display;
     };
     SDL_Window *sdlWindow = nullptr;
-    SDL_Surface *sdlWindowSurface = nullptr;
+    SDL_Renderer *sdlRenderer = nullptr;
     SDL_GLContext sdlOpenGlContext = nullptr;
 
     Sdl2WinParams *CalculateWindowParameters();


### PR DESCRIPTION
Fixed: assertion while interrupting clip playback
Fixed: selecting opengl renderer instead of default one on SDL window creation
Fixed: temporary file creation while saving a game