### PR TITLE
Fix case-sensitiveness (fix #175, #178 and #179)

### DIFF
--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -72,6 +72,7 @@
 #include "Media/MediaPlayer.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 #include "Platform/OSWindow.h"
 #include "Platform/OSWindowFactory.h"
 
@@ -868,20 +869,20 @@ void FinalInitialization() {
 
 bool MM7_LoadLods() {
     pIcons_LOD = new LODFile_IconsBitmaps;
-    if (!pIcons_LOD->Load(MakeDataPath("data/icons.lod"), "icons")) {
+    if (!pIcons_LOD->Load(MakeDataPath(ICONS_LOD_FILE), "icons")) {
         Error("Some files are missing\n\nPlease Reinstall.");
         return false;
     }
     pIcons_LOD->_011BA4_debug_paletted_pixels_uncompressed = false;
 
     pEvents_LOD = new LODFile_IconsBitmaps;
-    if (!pEvents_LOD->Load(MakeDataPath("data/events.lod").c_str(), "icons")) {
+    if (!pEvents_LOD->Load(MakeDataPath(EVENTS_LOD_FILE).c_str(), "icons")) {
         Error("Some files are missing\n\nPlease Reinstall.");
         return false;
     }
 
     pBitmaps_LOD = new LODFile_IconsBitmaps;
-    if (!pBitmaps_LOD->Load(MakeDataPath("data/bitmaps.lod").c_str(), "bitmaps")) {
+    if (!pBitmaps_LOD->Load(MakeDataPath(BITMAPS_LOD_FILE).c_str(), "bitmaps")) {
         Error(
             localization->GetString(LSTR_PLEASE_REINSTALL),
             localization->GetString(LSTR_REINSTALL_NECESSARY)
@@ -890,7 +891,7 @@ bool MM7_LoadLods() {
     }
 
     pSprites_LOD = new LODFile_Sprites;
-    if (!pSprites_LOD->LoadSprites(MakeDataPath("data/sprites.lod"))) {
+    if (!pSprites_LOD->LoadSprites(MakeDataPath(SPRITES_LOD_FILE))) {
         Error(
             localization->GetString(LSTR_PLEASE_REINSTALL),
             localization->GetString(LSTR_REINSTALL_NECESSARY)

--- a/Engine/Graphics/DecorationList.cpp
+++ b/Engine/Graphics/DecorationList.cpp
@@ -9,6 +9,7 @@
 #include "Sprites.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 struct DecorationList *pDecorationList;
 
@@ -49,7 +50,7 @@ void DecorationList::InitializeDecorationSprite(unsigned int uDecID) {
 }
 
 void DecorationList::ToFile() {
-    FILE *file = fcaseopen("data/ddeclist.bin", "wb");
+    FILE *file = fcaseopen(DATA_PATH "/ddeclist.bin", "wb");
     if (file == nullptr) {
         Error("Unable to save ddeclist.bin!", 0);
     }

--- a/Engine/Graphics/Image.cpp
+++ b/Engine/Graphics/Image.cpp
@@ -16,6 +16,7 @@
 #include "Engine/Tables/FrameTableInc.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "PaletteManager.h"
 
@@ -74,7 +75,7 @@ Texture *TextureFrame::GetTexture() {
 
 void TextureFrameTable::ToFile() {
     TextureFrameTable *v1 = this;
-    FILE *file = fcaseopen("data/dtft.bin", "wb");
+    FILE *file = fcaseopen(DATA_PATH "/dtft.bin", "wb");
     if (file == nullptr) {
         Error("Unable to save dtft.bin!", 0);
     }

--- a/Engine/Graphics/Overlays.cpp
+++ b/Engine/Graphics/Overlays.cpp
@@ -15,6 +15,7 @@
 #include "GUI/GUIWindow.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "Sprites.h"
 
@@ -110,7 +111,7 @@ void OverlayList::ToFile() {
     FILE *v2;  // eax@1
     // FILE *v3; // edi@1
 
-    v2 = fcaseopen("data/doverlay.bin", "wb");
+    v2 = fcaseopen(DATA_PATH "/doverlay.bin", "wb");
     // v3 = v2;
     if (!v2) Error("Unable to save doverlay.bin!");
     fwrite(this, 4, 1, v2);

--- a/Engine/Graphics/RenderBase.cpp
+++ b/Engine/Graphics/RenderBase.cpp
@@ -18,6 +18,7 @@
 #include "Engine/Graphics/Viewport.h"
 
 #include "Platform/OSWindow.h"
+#include "Platform/Path.h"
 
 
 bool RenderBase::Initialize() {
@@ -26,10 +27,10 @@ bool RenderBase::Initialize() {
         config->render_height
     );
 
-    if (!pD3DBitmaps.Open(MakeDataPath("data/d3dbitmap.hwl"))) {
+    if (!pD3DBitmaps.Open(MakeDataPath(D3DBITMAP_HWL_FILE))) {
         return false;
     }
-    if (!pD3DSprites.Open(MakeDataPath("data/d3dsprite.hwl"))) {
+    if (!pD3DSprites.Open(MakeDataPath(D3DSPRITE_HWL_FILE))) {
         return false;
     }
 

--- a/Engine/Graphics/Sprites.cpp
+++ b/Engine/Graphics/Sprites.cpp
@@ -20,6 +20,7 @@
 #include "Engine/Graphics/PaletteManager.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 
 struct SpriteFrameTable *pSpriteFrameTable;
@@ -329,7 +330,7 @@ SpriteFrame *SpriteFrameTable::GetFrameBy_x(unsigned int uSpriteID,
 }
 
 void SpriteFrameTable::ToFile() {
-    FILE *file = fcaseopen("data/dsft.bin", "wb");
+    FILE *file = fcaseopen(DATA_PATH "/dsft.bin", "wb");
     if (file == nullptr) {
         Error("Unable to save dsft.bin!");
     }

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Graphics/Sprites.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 LODFile_IconsBitmaps *pEvents_LOD = nullptr;
 
@@ -1208,7 +1209,7 @@ Texture_MM7 *LODFile_IconsBitmaps::GetTexture(int idx) {
 
 bool Initialize_GamesLOD_NewLOD() {
     pGames_LOD = new LOD::File();
-    if (pGames_LOD->Open(MakeDataPath("data/games.lod"))) {
+    if (pGames_LOD->Open(MakeDataPath(GAMES_LOD_FILE))) {
         pNew_LOD = new LOD::WriteableFile;
         pNew_LOD->AllocSubIndicesAndIO(300, 100000);
         return true;

--- a/Engine/Objects/Monsters.cpp
+++ b/Engine/Objects/Monsters.cpp
@@ -3,6 +3,7 @@
 #include "Engine/Engine.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "../LOD.h"
 #include "../Tables/FrameTableInc.h"
@@ -430,7 +431,7 @@ void MonsterList::ToFile() {
     FILE *v3;         // edi@1
 
     v1 = this;
-    v2 = fcaseopen("data/dmonlist.bin", "wb");
+    v2 = fcaseopen(DATA_PATH "/dmonlist.bin", "wb");
     v3 = v2;
     if (!v2) Error("Unable to save dmonlist.bin!");
     fwrite(v1, 4u, 1u, v2);

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "Engine/Engine.h"
 #include "Engine/EngineConfig.h"
@@ -88,9 +89,9 @@ void LoadGame(unsigned int uSlot) {
     pNew_LOD->CloseWriteFile();
     // uCurrentlyLoadedLevelType = LEVEL_null;
 
-    String filename = "saves/" + pSavegameList->pFileList[uSlot];
+    String filename = SAVES_PATH "/" + pSavegameList->pFileList[uSlot];
     filename = MakeDataPath(filename.c_str());
-    String to_file_path = MakeDataPath("data/new.lod");
+    String to_file_path = MakeDataPath(NEW_LOD_FILE);
     remove(to_file_path.c_str());
     if (!CopyFile(filename, to_file_path)) {
         Error("Failed to copy: %s", filename.c_str());
@@ -535,7 +536,7 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
     free(uncompressed_buff);
 
     if (IsAutoSAve) {
-        if (!CopyFile(MakeDataPath("data/new.lod"), MakeDataPath("saves/autosave.mm7"))) {
+        if (!CopyFile(MakeDataPath(NEW_LOD_FILE), MakeDataPath(SAVES_PATH "/autosave.mm7"))) {
             logger->Warning("Copy autosave.mm7 failed");
         }
     }
@@ -554,9 +555,9 @@ void DoSavegame(unsigned int uSlot) {
         pSavegameHeader[uSlot].playing_time = pParty->GetPlayingTime();
         pNew_LOD->Write("header.bin", &pSavegameHeader[uSlot], sizeof(SavegameHeader), 0);
         pNew_LOD->CloseWriteFile();  //закрыть
-        String file_path = StringPrintf("saves/save%03d.mm7", uSlot);
+        String file_path = StringPrintf(SAVES_PATH "/save%03d.mm7", uSlot);
         file_path = MakeDataPath(file_path.c_str());
-        CopyFile(MakeDataPath("data/new.lod"), file_path);
+        CopyFile(MakeDataPath(NEW_LOD_FILE), file_path);
     }
     GUI_UpdateWindows();
     pGUIWindow_CurrentMenu->Release();
@@ -584,7 +585,7 @@ void SavegameList::Initialize() {
     pSavegameList->Reset();
     uNumSavegameFiles = 0;
 
-    String saves_dir = MakeDataPath("Saves");
+    String saves_dir = MakeDataPath(SAVES_PATH);
 
     if (std::filesystem::exists(saves_dir)) {
         for (const auto& entry : std::filesystem::directory_iterator(saves_dir)) {
@@ -614,7 +615,7 @@ void SaveNewGame() {
         pNew_LOD->CloseWriteFile();
     }
 
-    String file_path = MakeDataPath("data/new.lod");
+    String file_path = MakeDataPath(NEW_LOD_FILE);
     remove(file_path.c_str());  // удалить new.lod
 
     LOD::FileHeader header;  // заголовок

--- a/Engine/Tables/IconFrameTable.cpp
+++ b/Engine/Tables/IconFrameTable.cpp
@@ -4,6 +4,7 @@
 #include "Engine/Serialization/LegacyImages.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "../LOD.h"
 #include "FrameTableInc.h"
@@ -78,7 +79,7 @@ void IconFrameTable::ToFile() {
     // IconFrameTable* Str = this;
 
     // v1 = Str;
-    v2 = fcaseopen("data/dift.bin", "wb");
+    v2 = fcaseopen(DATA_PATH "/dift.bin", "wb");
     // v3 = v2;
     if (!v2) Error("Unable to save dift.bin!");
     fwrite(this, 4, 1, v2);

--- a/Engine/Tables/PlayerFrameTable.cpp
+++ b/Engine/Tables/PlayerFrameTable.cpp
@@ -3,6 +3,7 @@
 #include "Engine/Engine.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "FrameTableInc.h"
 
@@ -70,7 +71,7 @@ void PlayerFrameTable::ToFile() {
     PlayerFrameTable *Str = this;
 
     v1 = Str;
-    v2 = fcaseopen("data/dpft.bin", "wb");
+    v2 = fcaseopen(DATA_PATH "/dpft.bin", "wb");
     v3 = v2;
     if (!v2) Error("Unable to save dpft.bin");
     fwrite(v1, 4, 1, v2);

--- a/Engine/Tables/TileTable.cpp
+++ b/Engine/Tables/TileTable.cpp
@@ -8,6 +8,7 @@
 #include "Engine/Serialization/LegacyImages.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 #include "FrameTableInc.h"
 #include "TileFrameTable.h"
@@ -81,7 +82,7 @@ void TileTable::ToFile() {
     TileTable *Str = this;
 
     v1 = Str;
-    v2 = fcaseopen("data/dtile.bin", "wb");
+    v2 = fcaseopen(DATA_PATH "/dtile.bin", "wb");
     v3 = v2;
     if (!v2) Error("Unable to save dtile.bin!");
     fwrite(v1, 4u, 1u, v2);

--- a/GUI/UI/UISaveLoad.cpp
+++ b/GUI/UI/UISaveLoad.cpp
@@ -24,6 +24,7 @@
 #include "GUI/UI/UIMainMenu.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 #include "Platform/OSWindow.h"
 
 
@@ -58,7 +59,7 @@ GUIWindow_Save::GUIWindow_Save() :
             file_name = "1.mm7";
         }
 
-        String str = "saves/" + file_name;
+        String str = SAVES_PATH "/" + file_name;
         str = MakeDataPath(str.c_str());
         if (_access(str.c_str(), 0) || _access(str.c_str(), 6)) {
             pSavegameUsedSlots[i] = 0;
@@ -161,7 +162,7 @@ GUIWindow_Load::GUIWindow_Load(bool ingame) :
     LOD::File pLODFile;
     Assert(sizeof(SavegameHeader) == 100);
     for (uint i = 0; i < uNumSavegameFiles; ++i) {
-        String str = "saves/" + pSavegameList->pFileList[i];
+        String str = SAVES_PATH "/" + pSavegameList->pFileList[i];
         str = MakeDataPath(str.c_str());
         if (_access(str.c_str(), 6)) {
             pSavegameUsedSlots[i] = 0;

--- a/Media/Audio/AudioPlayer.cpp
+++ b/Media/Audio/AudioPlayer.cpp
@@ -17,6 +17,7 @@
 #include "Media/Audio/OpenALSoundProvider.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 
 
 int sLastTrackLengthMS;
@@ -120,7 +121,7 @@ void AudioPlayer::MusicPlayTrack(MusicID eTrack) {
         }
         currentMusicTrack = -1;
 
-        String file_path = StringPrintf("Music%s%d.mp3", OS_GetDirSeparator().c_str(), eTrack);
+        String file_path = StringPrintf(MUSIC_PATH "/%d.mp3", eTrack);
         file_path = MakeDataPath(file_path.c_str());
         if (!FileExists(file_path.c_str())) {
             logger->Warning("%s not found", file_path.c_str());
@@ -358,7 +359,7 @@ struct SoundHeader_mm7 {
 void AudioPlayer::LoadAudioSnd() {
     static_assert(sizeof(SoundHeader_mm7) == 52, "Wrong type size");
 
-    std::string file_path = "Sounds" + OS_GetDirSeparator() + "Audio.snd";
+    std::string file_path = AUDIO_SND_FILE;
     fAudioSnd.open(MakeDataPath(file_path.c_str()), std::ios_base::binary);
     if (!fAudioSnd.good()) {
         logger->Warning("Can't open file: %s", file_path.c_str());

--- a/Media/MediaPlayer.cpp
+++ b/Media/MediaPlayer.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "Media/Audio/OpenALSoundProvider.h"
 
 #include "Platform/Api.h"
+#include "Platform/Path.h"
 #include "Platform/OSWindow.h"
 
 
@@ -737,11 +738,11 @@ class VideoList {
 
 void MPlayer::Initialize() {
     might_list = new VideoList();
-    std::string filename = MakeDataPath("anims/might7.vid");
+    std::string filename = MakeDataPath(MIGHT7_VID_FILE);
     might_list->Initialize(filename);
 
     magic_list = new VideoList();
-    filename = MakeDataPath("anims/magic7.vid");
+    filename = MakeDataPath(MAGIC7_VID_FILE);
     magic_list->Initialize(filename);
 }
 

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PLATFORM_SOURCES OSWindow.cpp
 )
 
 set(PLATFORM_HEADERS Api.h
+                     Path.h
                      OSWindow.h
                      OSWindowFactory.h
                      Sdl2KeyboardController.h

--- a/Platform/Path.h
+++ b/Platform/Path.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#define ANIMS_PATH   "Anims"
+#define DATA_PATH    "DATA"
+#define MUSIC_PATH   "Music"
+#define SAVES_PATH   "Saves"
+#define SOUNDS_PATH  "SOUNDS"
+
+
+#define MAGIC7_VID_FILE     ANIMS_PATH "/Magic7.vid"
+#define MIGHT7_VID_FILE     ANIMS_PATH "/Might7.vid"
+
+#define BITMAPS_LOD_FILE    DATA_PATH "/BITMAPS.LOD"
+#define EVENTS_LOD_FILE     DATA_PATH "/Events.lod"
+#define GAMES_LOD_FILE      DATA_PATH "/GAMES.LOD"
+#define ICONS_LOD_FILE      DATA_PATH "/ICONS.LOD"
+#define SPRITES_LOD_FILE    DATA_PATH "/SPRITES.LOD"
+#define D3DBITMAP_HWL_FILE  DATA_PATH "/d3dbitmap.hwl"
+#define D3DSPRITE_HWL_FILE  DATA_PATH "/d3dsprite.hwl"
+#define NEW_LOD_FILE        DATA_PATH "/new.lod"
+
+#define AUDIO_SND_FILE      SOUNDS_PATH "/Audio.snd"


### PR DESCRIPTION
On case-sensitive OSes, a lot of files are not properly loaded because
of case mismatches. Instead of hardcoding the paths, a new header file
(Platform/Path.h) now contains all the relevant strings.

Issue #178 is fixed in the sense that now loading a previous game on
Linux results in a crash instead of doing nothing: the game was not
loaded because of a case-sensitive mismatch on the `Saves` folder.