### PR TITLE
Bugfixes & improvements from 1h of gameplay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL 
   set(CMAKE_CXX_FLAGS "-std=c++17 -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 else()
   add_definitions(-DWINDOWS_IGNORE_PACKING_MISMATCH="") # vs2019 complains about using #pragma pack()
+  add_definitions(-DNOMINMAX) # please don't pull in these macros from <Windows.h>
   set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
   set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL 
 else()
   add_definitions(-DWINDOWS_IGNORE_PACKING_MISMATCH="") # vs2019 complains about using #pragma pack()
   add_definitions(-DNOMINMAX) # please don't pull in these macros from <Windows.h>
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS) # STL security warnings are just noise
   set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
   set(CMAKE_CXX_STANDARD 17)

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
-filter=-readability/casting,-legal/copyright,-runtime/printf,-runtime/references,-runtime/threadsafe_fn,-runtime/int,-whitespace/line_length,-readability/fn_size,-readability/todo,-runtime/string,-whitespace/empty_loop_body,-runtime/casting,-runtime/indentation_namespace,-whitespace/parens,-whitespace/comments,-build/c++11,-build/header_guard
+filter=-readability/casting,-legal/copyright,-runtime/printf,-runtime/references,-runtime/threadsafe_fn,-runtime/int,-whitespace/line_length,-readability/fn_size,-readability/todo,-runtime/string,-whitespace/empty_loop_body,-runtime/casting,-runtime/indentation_namespace,-whitespace/parens,-whitespace/comments,-build/c++11,-build/header_guard,-readability/inheritance
 exclude_files=(build|lib|out|thirdparty)/*
 linelength=120

--- a/Engine/EngineConfig.h
+++ b/Engine/EngineConfig.h
@@ -120,6 +120,8 @@ class EngineConfig {
     bool allow_lightmaps = true;
     bool allow_snow = false;
     bool extended_draw_distance = true;    // 2.5x draw distance
+    bool use_hwl_bitmaps = false;          // use low-res bitmaps from HWL files instead of hi-res ones from LODs
+                                           // (note that we'll have a separate options for sprites)
     bool show_fps = false;
     bool show_picked_face = false;           // red flash face pointed by mouse
     bool debug_all_magic = false;            // toggle all spellbook

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -95,8 +95,8 @@ Texture *Render::CreateTexture_PCXFromFile(const String &name) {
     return TextureD3D::Create(new PCX_File_Loader(name));
 }
 
-Texture *Render::CreateTexture_PCXFromLOD(void *pLOD, const String &name) {
-    return TextureD3D::Create(new PCX_LOD_Raw_Loader((LOD::File *)pLOD, name));
+Texture *Render::CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name) {
+    return TextureD3D::Create(new PCX_LOD_Raw_Loader(pLOD, name));
 }
 
 Texture *Render::CreateTexture_Blank(unsigned int width, unsigned int height,

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -2441,14 +2441,6 @@ void Render::_4A4CC9_AddSomeBillboard(SpellFX_Billboard *a1,
     }
 }
 
-HWLTexture *Render::LoadHwlBitmap(const char *name) {
-    return pD3DBitmaps.LoadTexture(name);
-}
-
-HWLTexture *Render::LoadHwlSprite(const char *name) {
-    return pD3DSprites.LoadTexture(name);
-}
-
 void Render::Update_Texture(Texture *texture) {
     // nothing
 }

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -2294,8 +2294,8 @@ void Render::DrawProjectile(float srcX, float srcY, float a3, float a4,
     int yDifference = bankersRounding(dstY - srcY);
     int absYDifference = abs(yDifference);
     int absXDifference = abs(xDifference);
-    unsigned int smallerabsdiff = min(absXDifference, absYDifference);
-    unsigned int largerabsdiff = max(absXDifference, absYDifference);
+    unsigned int smallerabsdiff = std::min(absXDifference, absYDifference);
+    unsigned int largerabsdiff = std::max(absXDifference, absYDifference);
     int v32 = (11 * smallerabsdiff >> 5) + largerabsdiff;
     double v16 = 1.0 / (double)v32;
     double v17 = (double)yDifference * v16 * a4;

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -3519,8 +3519,8 @@ void Render::DrawBuildingsD3D() {
     int v53;  // [sp+3Ch] [bp-1Ch]@8
 
     for (BSPModel &model : pOutdoor->pBModels) {
-        bool reachable;
-        if (!IsBModelVisible(&model, 256, &reachable)) {
+        bool reachable_unused;
+        if (!IsBModelVisible(&model, 256, &reachable_unused)) {
             continue;
         }
         model.field_40 |= 1;

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -108,7 +108,7 @@ Texture *Render::CreateTexture_Blank(unsigned int width, unsigned int height,
 
 
 Texture *Render::CreateTexture(const String &name) {
-    return TextureD3D::Create(new Bitmaps_LOD_Loader(pBitmaps_LOD, name));
+    return TextureD3D::Create(new Bitmaps_LOD_Loader(pBitmaps_LOD, name, engine->config->use_hwl_bitmaps));
 }
 
 Texture *Render::CreateSprite(const String &name, unsigned int palette_id,

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -3519,8 +3519,8 @@ void Render::DrawBuildingsD3D() {
     int v53;  // [sp+3Ch] [bp-1Ch]@8
 
     for (BSPModel &model : pOutdoor->pBModels) {
-        int reachable;
-        if (!IsBModelVisible(&model, &reachable)) {
+        bool reachable;
+        if (!IsBModelVisible(&model, 256, &reachable)) {
             continue;
         }
         model.field_40 |= 1;

--- a/Engine/Graphics/Direct3D/Render.h
+++ b/Engine/Graphics/Direct3D/Render.h
@@ -30,7 +30,7 @@ class Render : public RenderBase {
     );
     virtual ~Render();
 
-    virtual bool Initialize();
+    virtual bool Initialize() override;
 
     virtual bool NuklearInitialize(struct nk_tex_font *tfont);
     virtual bool NuklearCreateDevice();
@@ -41,167 +41,164 @@ class Render : public RenderBase {
     virtual struct nk_image NuklearImageLoad(Image *img);
     virtual void NuklearImageFree(Image *img);
 
-    virtual Texture *CreateTexture_ColorKey(const String &name, uint16_t colorkey);
-    virtual Texture *CreateTexture_Solid(const String &name);
-    virtual Texture *CreateTexture_Alpha(const String &name);
+    virtual Texture *CreateTexture_ColorKey(const String &name, uint16_t colorkey) override;
+    virtual Texture *CreateTexture_Solid(const String &name) override;
+    virtual Texture *CreateTexture_Alpha(const String &name) override;
 
-    virtual Texture *CreateTexture_PCXFromFile(const String &name);
-    virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromNewLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name);
+    virtual Texture *CreateTexture_PCXFromFile(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromNewLOD(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name) override;
 
     virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height,
-        IMAGE_FORMAT format, const void *pixels = nullptr);
+        IMAGE_FORMAT format, const void *pixels = nullptr) override;
 
-    virtual Texture *CreateTexture(const String &name);
+    virtual Texture *CreateTexture(const String &name) override;
     virtual Texture *CreateSprite(const String &name, unsigned int palette_id,
-                                  unsigned int lod_sprite_id);
+                                  unsigned int lod_sprite_id) override;
 
-    virtual void ClearBlack();
-    virtual void PresentBlackScreen();
+    virtual void ClearBlack() override;
+    virtual void PresentBlackScreen() override;
 
-    virtual void SaveWinnersCertificate(const char *a1);
-    virtual void ClearTarget(unsigned int uColor);
-    virtual void Present();
+    virtual void SaveWinnersCertificate(const char *a1) override;
+    virtual void ClearTarget(unsigned int uColor) override;
+    virtual void Present() override;
 
-    virtual bool InitializeFullscreen();
+    virtual bool InitializeFullscreen() override;
 
-    virtual void CreateZBuffer();
-    virtual void Release();
+    virtual void CreateZBuffer() override;
+    virtual void Release() override;
 
-    virtual bool SwitchToWindow();
-    virtual void RasterLine2D(int uX, int uY, int uZ, int uW, uint16_t uColor);
-    virtual void ClearZBuffer();
-    virtual void RestoreFrontBuffer();
-    virtual void RestoreBackBuffer();
-    virtual void BltBackToFontFast(int a2, int a3, Rect *pSrcRect);
-    virtual void BeginSceneD3D();
+    virtual bool SwitchToWindow() override;
+    virtual void RasterLine2D(int uX, int uY, int uZ, int uW, uint16_t uColor) override;
+    virtual void ClearZBuffer() override;
+    virtual void RestoreFrontBuffer() override;
+    virtual void RestoreBackBuffer() override;
+    virtual void BltBackToFontFast(int a2, int a3, Rect *pSrcRect) override;
+    virtual void BeginSceneD3D() override;
 
-    virtual unsigned int GetActorTintColor(int DimLevel, int tint, float WorldViewX, int a5, RenderBillboard *Billboard);
+    virtual unsigned int GetActorTintColor(int DimLevel, int tint, float WorldViewX, int a5, RenderBillboard *Billboard) override;
 
-    virtual void DrawPolygon(struct Polygon *a3);
+    virtual void DrawPolygon(struct Polygon *a3) override;
     virtual void DrawTerrainPolygon(struct Polygon *a4, bool transparent,
-                                    bool clampAtTextureBorders);
+                                    bool clampAtTextureBorders) override;
     virtual void DrawIndoorPolygon(unsigned int uNumVertices,
                                    struct BLVFace *a3, int uPackedID,
-                                   unsigned int uColor, int a8);
+                                   unsigned int uColor, int a8) override;
 
-    virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene();
+    virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene() override;
     virtual void DrawBillboard_Indoor(SoftwareBillboard *pSoftBillboard,
-                                      RenderBillboard *billboard);
-    virtual void _4A4CC9_AddSomeBillboard(struct SpellFX_Billboard *a1, int diffuse);
-    virtual void DrawBillboardList_BLV();
+                                      RenderBillboard *billboard) override;
+    virtual void _4A4CC9_AddSomeBillboard(struct SpellFX_Billboard *a1, int diffuse) override;
+    virtual void DrawBillboardList_BLV() override;
 
     virtual void DrawProjectile(float srcX, float srcY, float a3, float a4,
                                 float dstX, float dstY, float a7, float a8,
-                                Texture *texture);
-    virtual void RemoveTextureFromDevice(Texture* texture);
-    virtual bool MoveTextureToDevice(Texture *texture);
+                                Texture *texture) override;
+    virtual void RemoveTextureFromDevice(Texture* texture) override;
+    virtual bool MoveTextureToDevice(Texture *texture) override;
 
-    virtual void Update_Texture(Texture *texture);
+    virtual void Update_Texture(Texture *texture) override;
 
-    virtual void DeleteTexture(Texture *texture);
+    virtual void DeleteTexture(Texture *texture) override;
 
-    virtual void BeginScene();
-    virtual void EndScene();
-    virtual void ScreenFade(unsigned int color, float t);
+    virtual void BeginScene() override;
+    virtual void EndScene() override;
+    virtual void ScreenFade(unsigned int color, float t) override;
 
     virtual void SetUIClipRect(unsigned int uX, unsigned int uY,
-                               unsigned int uZ, unsigned int uW);
-    virtual void ResetUIClipRect();
+                               unsigned int uZ, unsigned int uW) override;
+    virtual void ResetUIClipRect() override;
 
-    virtual void DrawTextureNew(float u, float v, class Image *);
-    virtual void DrawTextureAlphaNew(float u, float v, class Image *);
+    virtual void DrawTextureNew(float u, float v, class Image *) override;
+    virtual void DrawTextureAlphaNew(float u, float v, class Image *) override;
     virtual void DrawTextureCustomHeight(float u, float v, class Image *,
-                                         int height);
+                                         int height) override;
     virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y,
-                                   Image *);
-    virtual void DrawImage(Image *, const Rect &rect);
+                                   Image *) override;
+    virtual void DrawImage(Image *, const Rect &rect) override;
 
     virtual void ZBuffer_Fill_2(signed int a2, signed int a3, Image *pTexture,
-                                int a5);
-    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal);
+                                int a5) override;
+    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal) override;
     virtual void BlendTextures(int x, int y, Image *imgin, Image *imgblend,
-                               int time, int start_opacity, int end_opacity);
-    virtual void DrawMonsterPortrait(Rect rc, SpriteFrame *Portrait, int Y_Offset);
+                               int time, int start_opacity, int end_opacity) override;
+    virtual void DrawMonsterPortrait(Rect rc, SpriteFrame *Portrait, int Y_Offset) override;
 
     virtual void DrawMasked(float u, float v, class Image *img,
-                            unsigned int color_dimming_level, uint16_t mask);
-    virtual void TexturePixelRotateDraw(float u, float v, Image * img, int time);
-    virtual void DrawTextureGrayShade(float u, float v, class Image *a4);
-    virtual void DrawTransparentRedShade(float u, float v, class Image *a4);
+                            unsigned int color_dimming_level, uint16_t mask) override;
+    virtual void TexturePixelRotateDraw(float u, float v, Image * img, int time) override;
+    virtual void DrawTextureGrayShade(float u, float v, class Image *a4) override;
+    virtual void DrawTransparentRedShade(float u, float v, class Image *a4) override;
     virtual void DrawTransparentGreenShade(float u, float v,
-                                           class Image *pTexture);
+                                           class Image *pTexture) override;
     virtual void DrawFansTransparent(const RenderVertexD3D3 *vertices,
-                                     unsigned int num_vertices);
+                                     unsigned int num_vertices) override;
 
-    virtual void MaskGameViewport();
+    virtual void MaskGameViewport() override;
 
     virtual void DrawTextAlpha(int x, int y, uint8_t *font_pixels, int a5,
                                unsigned int uFontHeight, uint8_t *pPalette,
-                               bool present_time_transparency);
+                               bool present_time_transparency) override;
     virtual void DrawText(int uOutX, int uOutY, uint8_t *pFontPixels,
                           unsigned int uCharWidth, unsigned int uCharHeight,
                           uint8_t *pFontPalette, uint16_t uFaceColor,
-                          uint16_t uShadowColor);
+                          uint16_t uShadowColor) override;
 
     virtual void FillRectFast(unsigned int uX, unsigned int uY,
                               unsigned int uWidth, unsigned int uHeight,
-                              unsigned int uColor16);
+                              unsigned int uColor16) override;
 
-    virtual void DrawBuildingsD3D();
+    virtual void DrawBuildingsD3D() override;
 
-    virtual void DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID);
-    virtual void DrawOutdoorSkyD3D();
+    virtual void DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) override;
+    virtual void DrawOutdoorSkyD3D() override;
 
-    virtual void PrepareDecorationsRenderList_ODM();
+    virtual void PrepareDecorationsRenderList_ODM() override;
 
-    virtual void RenderTerrainD3D();
+    virtual void RenderTerrainD3D() override;
 
-    virtual bool AreRenderSurfacesOk();
+    virtual bool AreRenderSurfacesOk() override;
 
-    virtual Image *TakeScreenshot(unsigned int width, unsigned int height);
+    virtual Image *TakeScreenshot(unsigned int width, unsigned int height) override;
     virtual void SaveScreenshot(const String &filename, unsigned int width,
-                                unsigned int height);
+                                unsigned int height) override;
     virtual void PackScreenshot(unsigned int width, unsigned int height,
                                 void *out_data, unsigned int data_size,
-                                unsigned int *screenshot_size);
-    virtual void SavePCXScreenshot();
+                                unsigned int *screenshot_size) override;
+    virtual void SavePCXScreenshot() override;
 
-    virtual int GetActorsInViewport(int pDepth);
+    virtual int GetActorsInViewport(int pDepth) override;
 
-    virtual void BeginLightmaps();
-    virtual void EndLightmaps();
-    virtual void BeginLightmaps2();
-    virtual void EndLightmaps2();
+    virtual void BeginLightmaps() override;
+    virtual void EndLightmaps() override;
+    virtual void BeginLightmaps2() override;
+    virtual void EndLightmaps2() override;
     virtual bool DrawLightmap(struct Lightmap *pLightmap,
-                              struct Vec3_float_ *pColorMult, float z_bias);
+                              struct Vec3_float_ *pColorMult, float z_bias) override;
 
-    virtual void BeginDecals();
-    virtual void EndDecals();
-    virtual void DrawDecal(struct Decal *pDecal, float z_bias);
+    virtual void BeginDecals() override;
+    virtual void EndDecals() override;
+    virtual void DrawDecal(struct Decal *pDecal, float z_bias) override;
 
     virtual void do_draw_debug_line_d3d(const RenderVertexD3D3 *pLineBegin,
                                         signed int sDiffuseBegin,
                                         const RenderVertexD3D3 *pLineEnd,
-                                        signed int sDiffuseEnd, float z_stuff);
+                                        signed int sDiffuseEnd, float z_stuff) override;
     virtual void DrawLines(const RenderVertexD3D3 *vertices,
-                           unsigned int num_vertices);
+                           unsigned int num_vertices) override;
 
     virtual void DrawSpecialEffectsQuad(const RenderVertexD3D3 *vertices,
-                                        Texture *texture);
+                                        Texture *texture) override;
 
     virtual void am_Blt_Chroma(Rect *pSrcRect, Point *pTargetPoint, int a3,
-                               int blend_mode);
-
-    virtual HWLTexture *LoadHwlBitmap(const char *name);
-    virtual HWLTexture *LoadHwlSprite(const char *name);
+                               int blend_mode) override;
 
  public:
-    virtual void WritePixel16(int x, int y, uint16_t color);
+    virtual void WritePixel16(int x, int y, uint16_t color) override;
 
-    virtual unsigned int GetRenderWidth() const;
-    virtual unsigned int GetRenderHeight() const;
+    virtual unsigned int GetRenderWidth() const override;
+    virtual unsigned int GetRenderHeight() const override;
 
     friend void Present_NoColorKey();
 

--- a/Engine/Graphics/Direct3D/Render.h
+++ b/Engine/Graphics/Direct3D/Render.h
@@ -48,7 +48,7 @@ class Render : public RenderBase {
     virtual Texture *CreateTexture_PCXFromFile(const String &name);
     virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name);
     virtual Texture *CreateTexture_PCXFromNewLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromLOD(void *pLOD, const String &name);
+    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name);
 
     virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height,
         IMAGE_FORMAT format, const void *pixels = nullptr);

--- a/Engine/Graphics/IRender.h
+++ b/Engine/Graphics/IRender.h
@@ -540,5 +540,5 @@ bool sub_475F30(int *a1, struct BLVFace *a2, int a3, int a4, int a5, int a6,
 
 class BSPModel;
 
-bool IsBModelVisible(BSPModel *model, int *unused);
+bool IsBModelVisible(BSPModel *model, int reachable_depth, bool *reachable);
 inline uint32_t PixelDim(uint32_t pix, int dimming);

--- a/Engine/Graphics/IRender.h
+++ b/Engine/Graphics/IRender.h
@@ -25,6 +25,10 @@ struct SpellFxRenderer;
 class Vis;
 class Log;
 
+namespace LOD {
+class File;
+}
+
 bool PauseGameDrawing();
 
 struct RenderBillboard {
@@ -254,7 +258,7 @@ class IRender {
     virtual Texture *CreateTexture_PCXFromFile(const String &name) = 0;
     virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name) = 0;
     virtual Texture *CreateTexture_PCXFromNewLOD(const String &name) = 0;
-    virtual Texture *CreateTexture_PCXFromLOD(void *pLOD, const String &name) = 0;
+    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name) = 0;
 
     virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height,
         IMAGE_FORMAT format, const void *pixels = nullptr) = 0;

--- a/Engine/Graphics/Image.h
+++ b/Engine/Graphics/Image.h
@@ -81,8 +81,8 @@ struct TextureHeader {
     uint32_t uTextureSize;
     uint16_t uTextureWidth;
     uint16_t uTextureHeight;
-    int16_t uWidthLn2;
-    int16_t uHeightLn2;
+    int16_t uWidthLn2;  // log2(uTextureWidth)
+    int16_t uHeightLn2;  // log2(uTextureHeight)
     int16_t uWidthMinus1;
     int16_t uHeightMinus1;
     int16_t palette_id1;
@@ -90,7 +90,7 @@ struct TextureHeader {
     uint32_t uDecompressedSize;
     uint32_t pBits;  // 0x0002 - generate mipmaps
                      // 0x0200 - 0th palette entry is transparent, else colorkey
-                     // (7FF)
+                     // 0x0400 - don't free buffers (???)
 };
 #pragma pack(pop)
 

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -283,7 +283,7 @@ bool Bitmaps_LOD_Loader::Load(unsigned int *width, unsigned int *height,
             pixels[p * 4 + 0] = tex->pPalette24[3 * pal + 2];
             pixels[p * 4 + 1] = tex->pPalette24[3 * pal + 1];
             pixels[p * 4 + 2] = tex->pPalette24[3 * pal + 0];
-            pixels[p * 4 + 3] = 255;
+            pixels[p * 4 + 3] = (pal == 0) ? 0 : 255;
         }
 
         *format = IMAGE_FORMAT_A8R8G8B8;

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -272,10 +272,10 @@ bool Bitmaps_LOD_Loader::Load(unsigned int *width, unsigned int *height,
     *out_pixels = nullptr;
     *format = IMAGE_INVALID_FORMAT;
 
-    auto tex = lod->GetTexture(lod->LoadTexture(this->resource_name));
+    Texture_MM7 *tex = lod->GetTexture(lod->LoadTexture(this->resource_name));
 
     int num_pixels = tex->header.uTextureWidth * tex->header.uTextureHeight;
-    auto pixels = new uint16_t[num_pixels];
+    uint16_t *pixels = new uint16_t[num_pixels];
     if (pixels) {
         *width = tex->header.uTextureWidth;
         *height = tex->header.uTextureHeight;

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -81,7 +81,7 @@ bool ColorKey_LOD_Loader::Load(unsigned int *out_width,
     *out_format = IMAGE_INVALID_FORMAT;
 
     Texture_MM7 *tex = lod->GetTexture(
-        lod->LoadTexture(resource_name.c_str(), TEXTURE_24BIT_PALETTE));
+        lod->LoadTexture(resource_name, TEXTURE_24BIT_PALETTE));
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) ||
         (tex->paletted_pixels == nullptr)) {
         return false;
@@ -117,7 +117,7 @@ bool Image16bit_LOD_Loader::Load(unsigned int *out_width,
     *out_format = IMAGE_INVALID_FORMAT;
 
     Texture_MM7 *tex = lod->GetTexture(
-        lod->LoadTexture(resource_name.c_str(), TEXTURE_24BIT_PALETTE));
+        lod->LoadTexture(resource_name, TEXTURE_24BIT_PALETTE));
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) ||
         (tex->paletted_pixels == nullptr)) {
         return false;
@@ -152,7 +152,7 @@ bool Alpha_LOD_Loader::Load(unsigned int *out_width, unsigned int *out_height,
     *out_format = IMAGE_INVALID_FORMAT;
 
     Texture_MM7 *tex = lod->GetTexture(
-        lod->LoadTexture(resource_name.c_str(), TEXTURE_24BIT_PALETTE));
+        lod->LoadTexture(resource_name, TEXTURE_24BIT_PALETTE));
     if ((tex == nullptr) || (tex->pPalette24 == nullptr) ||
         (tex->paletted_pixels == nullptr)) {
         return false;
@@ -272,7 +272,7 @@ bool Bitmaps_LOD_Loader::Load(unsigned int *width, unsigned int *height,
     *out_pixels = nullptr;
     *format = IMAGE_INVALID_FORMAT;
 
-    auto tex = lod->GetTexture(lod->LoadTexture(this->resource_name.c_str()));
+    auto tex = lod->GetTexture(lod->LoadTexture(this->resource_name));
 
     int num_pixels = tex->header.uTextureWidth * tex->header.uTextureHeight;
     auto pixels = new uint16_t[num_pixels];
@@ -282,7 +282,7 @@ bool Bitmaps_LOD_Loader::Load(unsigned int *width, unsigned int *height,
         *format = IMAGE_FORMAT_A1R5G5B5;
 
         if (tex->header.pBits & 2) {  // hardware bitmap
-            HWLTexture *hwl = render->LoadHwlBitmap(this->resource_name.c_str());
+            HWLTexture *hwl = render->LoadHwlBitmap(this->resource_name);
             if (hwl) {
                 // linear scaling
                 for (int s = 0; s < tex->header.uTextureHeight; ++s) {
@@ -314,7 +314,7 @@ bool Sprites_LOD_Loader::Load(unsigned int *width, unsigned int *height,
     *out_pixels = nullptr;
     *format = IMAGE_INVALID_FORMAT;
 
-    HWLTexture *hwl = render->LoadHwlSprite(this->resource_name.c_str());
+    HWLTexture *hwl = render->LoadHwlSprite(this->resource_name);
     if (hwl) {
         int dst_width = hwl->uWidth;
         int dst_height = hwl->uHeight;

--- a/Engine/Graphics/ImageLoader.h
+++ b/Engine/Graphics/ImageLoader.h
@@ -120,10 +120,10 @@ class PCX_LOD_Compressed_Loader : public PCX_Loader {
 
 class Bitmaps_LOD_Loader : public ImageLoader {
  public:
-    inline Bitmaps_LOD_Loader(LODFile_IconsBitmaps *lod,
-                              const String &filename) {
+    inline Bitmaps_LOD_Loader(LODFile_IconsBitmaps *lod, const String &filename, bool use_hwl) {
         this->resource_name = filename;
         this->lod = lod;
+        this->use_hwl = use_hwl;
     }
 
     virtual bool Load(unsigned int *width, unsigned int *height,
@@ -131,6 +131,7 @@ class Bitmaps_LOD_Loader : public ImageLoader {
 
  protected:
     LODFile_IconsBitmaps *lod;
+    bool use_hwl;
 };
 
 class Sprites_LOD_Loader : public ImageLoader {

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -3416,8 +3416,10 @@ char DoInteractionWithTopmostZObject(int pid) {
             if (pActors[id].uAIState == Dead) {
                 pActors[id].LootActor();
             } else {
-                extern bool ActorInteraction(unsigned int id);
-                ActorInteraction(id);
+                extern bool CanInteractWithActor(unsigned int id);
+                extern void InteractWithActor(unsigned int id);
+                if (CanInteractWithActor(id))
+                    InteractWithActor(id);
             }
             break;
 

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -51,8 +51,6 @@ LEVEL_TYPE uCurrentlyLoadedLevelType = LEVEL_null;
 
 LightsData Lights;
 stru337_unused _DLV_header_unused;
-BspRenderer_PortalViewportData _PortalViewportData_unused;
-BspRenderer *pBspRenderer = new BspRenderer;
 stru141_actor_collision_object _actor_collision_struct;
 // std::array<stru352, 480> stru_F83B80;
 
@@ -147,16 +145,11 @@ void PrepareDrawLists_BLV() {
     pIndoor->PrepareItemsRenderList_BLV();
     pIndoor->PrepareActorRenderList_BLV();
 
-    // for (uint i = 0; i < pBspRenderer->uNumVisibleNotEmptySectors; ++i) {
-    //     v7 = pBspRenderer->pVisibleSectorIDs_toDrawDecorsActorsEtcFrom[i];
-    //     v8 = &pIndoor->pSectors[pBspRenderer->pVisibleSectorIDs_toDrawDecorsActorsEtcFrom[i]];
-
     for (int i = 1; i < pIndoor->uNumSectors; i++) {
         v8 = &pIndoor->pSectors[i];
         for (uint j = 0; j < v8->uNumDecorations; ++j)
             pIndoor->PrepareDecorationsRenderList_BLV(v8->pDecorationIDs[j], i);
     }
-        // }
 
     FindBillboardsLightLevels_BLV();
     // engine->PrepareBloodsplats();

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -3941,7 +3941,7 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 }
             }
         }
-        v2 = fixpoint_mul(58500, v2);
+        v2 = fixpoint_mul(58500, v2);  // 58500 is roughly 0.89
         v1 = fixpoint_mul(58500, v1);
         pParty->uFallSpeed = fixpoint_mul(58500, pParty->uFallSpeed);
     }
@@ -4569,7 +4569,7 @@ int stru141_actor_collision_object::CalcMovementExtents(int dt) {  // true if no
         this->field_80 = -1;
         this->field_88 = -1;
         // this->sMinZ = v27;
-        this->field_7C = 0xFFFFFFu;
+        this->field_7C = 0xFFFFFFu;  // 255.0 fixpoint
         result = 0;
     }
     return result;

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -51,6 +51,8 @@ LEVEL_TYPE uCurrentlyLoadedLevelType = LEVEL_null;
 
 LightsData Lights;
 stru337_unused _DLV_header_unused;
+BspRenderer_PortalViewportData _PortalViewportData_unused;
+BspRenderer *pBspRenderer = new BspRenderer;
 stru141_actor_collision_object _actor_collision_struct;
 // std::array<stru352, 480> stru_F83B80;
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -733,7 +733,77 @@ bool PointInPolyIndoor(int x, int y, int z, struct BLVFace *face);
 bool PointInPolyOutdoor(int a1, int a2, int a3, struct ODMFace *face,
                 struct BSPVertexBuffer *a5);
 
-#pragma once
+#pragma pack(push, 1)
+struct BspRenderer_PortalViewportData {
+    void GetViewportData(int16_t x, int y, int16_t z, int w);
+
+    int _viewport_space_y;
+    int _viewport_space_w;
+    int _viewport_space_x;
+    int _viewport_space_z;
+    int _viewport_x_minID;
+    int _viewport_z_maxID;
+    int16_t viewport_left_side[480];
+    int16_t viewport_right_side[480];
+};
+#pragma pack(pop)
+extern BspRenderer_PortalViewportData _PortalViewportData_unused;
+
+/*  164 */
+#pragma pack(push, 1)
+struct BspRenderer_stru0 {
+    //----- (0043F2BF) --------------------------------------------------------
+    inline BspRenderer_stru0() {}
+
+    //----- (0043F2A9) --------------------------------------------------------
+    ~BspRenderer_stru0() {}
+
+    uint16_t uSectorID = 0;
+    uint16_t uViewportX;
+    uint16_t uViewportY;
+    uint16_t uViewportZ;
+    uint16_t uViewportW;
+    int16_t field_A = 0;
+    BspRenderer_PortalViewportData PortalScreenData{};
+    uint16_t uFaceID;
+    int16_t field_7A6 = 0;
+    unsigned int viewing_portal_id;  // portal through which we're seeing this node
+    IndoorCameraD3D_Vec4 std__vector_0007AC[4];  // frustum planes
+    RenderVertexSoft pPortalBounding[4];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct BspFace {
+    uint16_t uFaceID;
+    uint16_t uNodeID;
+};
+#pragma pack(pop)
+
+/*  163 */
+#pragma pack(push, 1)
+struct BspRenderer {  // stru170
+    //----- (0043F282) --------------------------------------------------------
+    inline BspRenderer() {
+        num_faces = 0;
+        num_nodes = 0;
+        uNumVisibleNotEmptySectors = 0;
+    }
+
+    void AddFaceToRenderList_d3d(unsigned int node_id, unsigned int uFaceID);
+    void MakeVisibleSectorList();
+    // void DrawFaceOutlines();
+
+    unsigned int num_faces;
+    // __int16 pFaceIDs[2000];
+    BspFace faces[1000]{};
+    // char field_130[3700];
+    unsigned int num_nodes;
+    BspRenderer_stru0 nodes[150];
+    unsigned int uNumVisibleNotEmptySectors;
+    uint16_t pVisibleSectorIDs_toDrawDecorsActorsEtcFrom[6]{};
+};
+#pragma pack(pop)
 
 void FindBillboardsLightLevels_BLV();
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -799,10 +799,6 @@ struct BspRenderer {  // stru170
         uNumVisibleNotEmptySectors = 0;
     }
 
-    void AddFaceToRenderList_d3d(unsigned int node_id, unsigned int uFaceID);
-    void MakeVisibleSectorList();
-    // void DrawFaceOutlines();
-
     unsigned int num_faces;
     // __int16 pFaceIDs[2000];
     BspFace faces[1000] {};

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -698,7 +698,6 @@ struct BLVRenderParams {
     int uViewportWidth = 0;
     int uViewportCenterX = 0;
     int uViewportCenterY = 0;
-    struct BspRenderer_PortalViewportData *field_7C = nullptr;
     unsigned int uNumFacesRenderedThisFrame = 0;
     int field_84 = 0;
     int field_88 = 0;
@@ -710,9 +709,6 @@ struct BLVRenderParams {
 extern BLVRenderParams *pBLVRenderParams;
 
 // int GetPortalScreenCoord(unsigned int uFaceID);
-// bool PortalFrustrum(int pNumVertices, struct BspRenderer_PortalViewportData *a2,
-//                   struct BspRenderer_PortalViewportData *near_portal,
-//                    int uFaceID);
 // void PrepareBspRenderList_BLV();
 // void AddBspNodeToRenderList(unsigned int node_id);
 // void sub_4406BC(unsigned int node_id, unsigned int uFirstNode);  // idb
@@ -738,79 +734,6 @@ bool PointInPolyOutdoor(int a1, int a2, int a3, struct ODMFace *face,
                 struct BSPVertexBuffer *a5);
 
 #pragma once
-
-/*  165 */
-#pragma pack(push, 1)
-struct BspRenderer_PortalViewportData {
-    void GetViewportData(int16_t x, int y, int16_t z, int w);
-
-    int _viewport_space_y;
-    int _viewport_space_w;
-    int _viewport_space_x;
-    int _viewport_space_z;
-    int _viewport_x_minID;
-    int _viewport_z_maxID;
-    int16_t viewport_left_side[480];
-    int16_t viewport_right_side[480];
-};
-#pragma pack(pop)
-extern BspRenderer_PortalViewportData _PortalViewportData_unused;
-
-/*  164 */
-#pragma pack(push, 1)
-struct BspRenderer_stru0 {
-    //----- (0043F2BF) --------------------------------------------------------
-    inline BspRenderer_stru0() {
-    }
-
-    //----- (0043F2A9) --------------------------------------------------------
-    ~BspRenderer_stru0() {
-    }
-
-    uint16_t uSectorID = 0;
-    uint16_t uViewportX;
-    uint16_t uViewportY;
-    uint16_t uViewportZ;
-    uint16_t uViewportW;
-    int16_t field_A = 0;
-    BspRenderer_PortalViewportData PortalScreenData {};
-    uint16_t uFaceID;
-    int16_t field_7A6 = 0;
-    unsigned int viewing_portal_id;  // portal through which we're seeing this node
-    IndoorCameraD3D_Vec4 std__vector_0007AC[4];  // frustum planes
-    RenderVertexSoft pPortalBounding[4];
-};
-#pragma pack(pop)
-
-#pragma pack(push, 1)
-struct BspFace {
-    uint16_t uFaceID;
-    uint16_t uNodeID;
-};
-#pragma pack(pop)
-
-/*  163 */
-#pragma pack(push, 1)
-struct BspRenderer {  // stru170
-    //----- (0043F282) --------------------------------------------------------
-    inline BspRenderer() {
-        num_faces = 0;
-        num_nodes = 0;
-        uNumVisibleNotEmptySectors = 0;
-    }
-
-    unsigned int num_faces;
-    // __int16 pFaceIDs[2000];
-    BspFace faces[1000] {};
-    // char field_130[3700];
-    unsigned int num_nodes;
-    BspRenderer_stru0 nodes[150];
-    unsigned int uNumVisibleNotEmptySectors;
-    uint16_t pVisibleSectorIDs_toDrawDecorsActorsEtcFrom[6] {};
-};
-#pragma pack(pop)
-
-extern struct BspRenderer *pBspRenderer;  // idb
 
 void FindBillboardsLightLevels_BLV();
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -232,7 +232,7 @@ struct stru154 {
     void GetFacePlane(struct ODMFace *pFace, struct BSPVertexBuffer *pVertices,
                       struct Vec3_float_ *pOutNormal, float *pOutDist);
 
-    void (***vdestructor_ptr)(stru154 *, bool);
+    void (***vdestructor_ptr)(stru154 *, bool) = nullptr;
     Plane_float_ face_plane {};
     PolygonType polygonType {};
     char field_15 = 0;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1,5 +1,4 @@
 #ifdef _WINDOWS
-    #define NOMINMAX
     #include <Windows.h>
 
     #pragma comment(lib, "opengl32.lib")

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -77,7 +77,7 @@ void Polygon::_normalize_v_18() {
     }
 }
 
-bool IsBModelVisible(BSPModel *model, int *reachable) {
+bool IsBModelVisible(BSPModel *model, int reachable_depth, bool *reachable) {
     // checks if model is visible in FOV cone
     float halfangle = (pODMRenderParams->uCameraFovInDegrees * pi_double / 180.0f) / 2;
     float rayx = model->vBoundingCenter.x - pIndoorCameraD3D->vPartyPos.x;
@@ -86,7 +86,7 @@ bool IsBModelVisible(BSPModel *model, int *reachable) {
     // approx distance
     int dist = int_get_vector_length(abs(rayx), abs(rayy), 0);
     *reachable = false;
-    if (dist < model->sBoundingRadius + 256) *reachable = true;
+    if (dist < model->sBoundingRadius + reachable_depth) *reachable = true;
 
     // dot product of camvec and ray - size in forward
     float frontvec = rayx * pIndoorCameraD3D->fRotationZCosine + rayy * pIndoorCameraD3D->fRotationZSine;
@@ -4189,8 +4189,8 @@ void RenderOpenGL::DrawBuildingsD3D() {
     int v53;  // [sp+3Ch] [bp-1Ch]@8
 
     for (BSPModel& model : pOutdoor->pBModels) {
-        int reachable;
-        if (!IsBModelVisible(&model, &reachable)) {
+        bool reachable;
+        if (!IsBModelVisible(&model, 256, &reachable)) {
             continue;
         }
         model.field_40 |= 1;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -3419,7 +3419,6 @@ void RenderOpenGL::RenderTerrainD3D() {
 
 void RenderOpenGL::DrawTerrainPolygon(struct Polygon *poly, bool transparent, bool clampAtTextureBorders) {
     int v11;           // eax@5
-    unsigned int v45;  // eax@28
 
     unsigned int uNumVertices = poly->uNumVertices;
 
@@ -4377,7 +4376,6 @@ void RenderOpenGL::DrawPolygon(struct Polygon *pPolygon) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-    unsigned int v41;     // eax@29
     unsigned int sCorrectedColor;  // [sp+64h] [bp-4h]@4
 
     auto texture = (TextureOpenGL*)pPolygon->texture;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -2773,8 +2773,8 @@ Texture *RenderOpenGL::CreateTexture_PCXFromFile(const String &name) {
     return TextureOpenGL::Create(new PCX_File_Loader(name));
 }
 
-Texture *RenderOpenGL::CreateTexture_PCXFromLOD(void *pLOD, const String &name) {
-    return TextureOpenGL::Create(new PCX_LOD_Raw_Loader((LOD::File *)pLOD, name));
+Texture *RenderOpenGL::CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name) {
+    return TextureOpenGL::Create(new PCX_LOD_Raw_Loader(pLOD, name));
 }
 
 Texture *RenderOpenGL::CreateTexture_Blank(unsigned int width, unsigned int height,
@@ -3942,12 +3942,17 @@ void RenderOpenGL::DrawTextureAlphaNew(float u, float v, Image *img) {
 void RenderOpenGL::DrawTextureNew(float u, float v, Image *tex) {
     if (!tex) __debugbreak();
 
+    TextureOpenGL* texture = dynamic_cast<TextureOpenGL*>(tex);
+    if (!texture) {
+        __debugbreak();
+        return;
+    }
+
     glEnable(GL_TEXTURE_2D);
     glColor3f(1, 1, 1);
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    auto texture = (TextureOpenGL *)tex;
     glBindTexture(GL_TEXTURE_2D, texture->GetOpenGlTexture());
 
     int clipx = this->clip_x;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -4375,6 +4375,9 @@ void RenderOpenGL::DrawPolygon(struct Polygon *pPolygon) {
         return;
     }
 
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
     unsigned int v41;     // eax@29
     unsigned int sCorrectedColor;  // [sp+64h] [bp-4h]@4
 

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -4187,8 +4187,8 @@ void RenderOpenGL::DrawBuildingsD3D() {
     int v53;  // [sp+3Ch] [bp-1Ch]@8
 
     for (BSPModel& model : pOutdoor->pBModels) {
-        bool reachable;
-        if (!IsBModelVisible(&model, 256, &reachable)) {
+        bool reachable_unused;
+        if (!IsBModelVisible(&model, 256, &reachable_unused)) {
             continue;
         }
         model.field_40 |= 1;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -2784,7 +2784,7 @@ Texture *RenderOpenGL::CreateTexture_Blank(unsigned int width, unsigned int heig
 
 
 Texture *RenderOpenGL::CreateTexture(const String &name) {
-    return TextureOpenGL::Create(new Bitmaps_LOD_Loader(pBitmaps_LOD, name));
+    return TextureOpenGL::Create(new Bitmaps_LOD_Loader(pBitmaps_LOD, name, engine->config->use_hwl_bitmaps));
 }
 
 Texture *RenderOpenGL::CreateSprite(const String &name, unsigned int palette_id,

--- a/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -25,7 +25,7 @@ class RenderOpenGL : public RenderBase {
     );
     virtual ~RenderOpenGL();
 
-    virtual bool Initialize();
+    virtual bool Initialize() override;
 
     virtual bool NuklearInitialize(struct nk_tex_font *tfont);
     virtual bool NuklearCreateDevice();
@@ -36,171 +36,171 @@ class RenderOpenGL : public RenderBase {
     virtual struct nk_image NuklearImageLoad(Image *img);
     virtual void NuklearImageFree(Image *img);
 
-    virtual Texture *CreateTexture_ColorKey(const String &name, uint16_t colorkey);
-    virtual Texture *CreateTexture_Solid(const String &name);
-    virtual Texture *CreateTexture_Alpha(const String &name);
+    virtual Texture *CreateTexture_ColorKey(const String &name, uint16_t colorkey) override;
+    virtual Texture *CreateTexture_Solid(const String &name) override;
+    virtual Texture *CreateTexture_Alpha(const String &name) override;
 
-    virtual Texture *CreateTexture_PCXFromFile(const String &name);
-    virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromNewLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name);
+    virtual Texture *CreateTexture_PCXFromFile(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromNewLOD(const String &name) override;
+    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name) override;
 
     virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height,
-        IMAGE_FORMAT format, const void *pixels = nullptr);
+        IMAGE_FORMAT format, const void *pixels = nullptr) override;
 
-    virtual Texture *CreateTexture(const String &name);
+    virtual Texture *CreateTexture(const String &name) override;
     virtual Texture *CreateSprite(
         const String &name, unsigned int palette_id,
-        /*refactor*/ unsigned int lod_sprite_id);
+        /*refactor*/ unsigned int lod_sprite_id) override;
 
-    virtual void ClearBlack();
-    virtual void PresentBlackScreen();
+    virtual void ClearBlack() override;
+    virtual void PresentBlackScreen() override;
 
-    virtual void SaveWinnersCertificate(const char *a1);
-    virtual void ClearTarget(unsigned int uColor);
-    virtual void Present();
+    virtual void SaveWinnersCertificate(const char *a1) override;
+    virtual void ClearTarget(unsigned int uColor) override;
+    virtual void Present() override;
 
-    virtual bool InitializeFullscreen();
+    virtual bool InitializeFullscreen() override;
 
-    virtual void CreateZBuffer();
-    virtual void Release();
+    virtual void CreateZBuffer() override;
+    virtual void Release() override;
 
-    virtual bool SwitchToWindow();
+    virtual bool SwitchToWindow() override;
     virtual void RasterLine2D(signed int uX, signed int uY, signed int uZ,
-                              signed int uW, unsigned __int16 uColor);
-    virtual void ClearZBuffer();
-    virtual void RestoreFrontBuffer();
-    virtual void RestoreBackBuffer();
-    virtual void BltBackToFontFast(int a2, int a3, Rect *pSrcRect);
-    virtual void BeginSceneD3D();
+                              signed int uW, unsigned __int16 uColor) override;
+    virtual void ClearZBuffer() override;
+    virtual void RestoreFrontBuffer() override;
+    virtual void RestoreBackBuffer() override;
+    virtual void BltBackToFontFast(int a2, int a3, Rect *pSrcRect) override;
+    virtual void BeginSceneD3D() override;
 
-    virtual unsigned int GetActorTintColor(int DimLevel, int tint, float WorldViewX, int a5, RenderBillboard *Billboard);
+    virtual unsigned int GetActorTintColor(int DimLevel, int tint, float WorldViewX, int a5, RenderBillboard *Billboard) override;
 
-    virtual void DrawPolygon(struct Polygon *a3);
+    virtual void DrawPolygon(struct Polygon *a3) override;
     virtual void DrawTerrainPolygon(struct Polygon *a4, bool transparent,
-                                    bool clampAtTextureBorders);
+                                    bool clampAtTextureBorders) override;
     virtual void DrawIndoorPolygon(unsigned int uNumVertices,
                                    struct BLVFace *a3, int uPackedID,
-                                   unsigned int uColor, int a8);
+                                   unsigned int uColor, int a8) override;
 
-    virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene();
+    virtual void DrawBillboards_And_MaybeRenderSpecialEffects_And_EndScene() override;
     virtual void DrawBillboard_Indoor(SoftwareBillboard *pSoftBillboard,
-                                      RenderBillboard *);
-    virtual void _4A4CC9_AddSomeBillboard(struct SpellFX_Billboard *a1, int diffuse);
-    virtual void DrawBillboardList_BLV();
+                                      RenderBillboard *) override;
+    virtual void _4A4CC9_AddSomeBillboard(struct SpellFX_Billboard *a1, int diffuse) override;
+    virtual void DrawBillboardList_BLV() override;
 
     virtual void DrawProjectile(float srcX, float srcY, float a3, float a4,
                                 float dstX, float dstY, float a7, float a8,
-                                Texture *texture);
+                                Texture *texture) override;
 
-    virtual void RemoveTextureFromDevice(Texture* texture);
-    virtual bool MoveTextureToDevice(Texture *texture);
+    virtual void RemoveTextureFromDevice(Texture* texture) override;
+    virtual bool MoveTextureToDevice(Texture *texture) override;
 
-    virtual void Update_Texture(Texture *texture);
+    virtual void Update_Texture(Texture *texture) override;
 
-    virtual void DeleteTexture(Texture *texture);
+    virtual void DeleteTexture(Texture *texture) override;
 
-    virtual void BeginScene();
-    virtual void EndScene();
-    virtual void ScreenFade(unsigned int color, float t);
+    virtual void BeginScene() override;
+    virtual void EndScene() override;
+    virtual void ScreenFade(unsigned int color, float t) override;
 
     virtual void SetUIClipRect(unsigned int uX, unsigned int uY,
-                               unsigned int uZ, unsigned int uW);
-    virtual void ResetUIClipRect();
+                               unsigned int uZ, unsigned int uW) override;
+    virtual void ResetUIClipRect() override;
 
-    virtual void DrawTextureNew(float u, float v, class Image *);
-    virtual void DrawTextureAlphaNew(float u, float v, class Image *);
+    virtual void DrawTextureNew(float u, float v, class Image *) override;
+    virtual void DrawTextureAlphaNew(float u, float v, class Image *) override;
 
         virtual void DrawTextureCustomHeight(float u, float v, class Image *,
-                                         int height);
+                                         int height) override;
     virtual void DrawTextureOffset(int x, int y, int offset_x, int offset_y,
-                                   Image *);
-    virtual void DrawImage(Image *, const Rect &rect);
+                                   Image *) override;
+    virtual void DrawImage(Image *, const Rect &rect) override;
 
     virtual void ZBuffer_Fill_2(signed int a2, signed int a3, Image *pTexture,
-                                int a5);
-    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal);
+                                int a5) override;
+    virtual void ZDrawTextureAlpha(float u, float v, Image *pTexture, int zVal) override;
     virtual void BlendTextures(int a2, int a3, Image *a4, Image *a5, int t,
-                               int start_opacity, int end_opacity);
-    virtual void TexturePixelRotateDraw(float u, float v, Image *img, int time);
-    virtual void DrawMonsterPortrait(Rect rc, SpriteFrame *Portrait_Sprite, int Y_Offset);
+                               int start_opacity, int end_opacity) override;
+    virtual void TexturePixelRotateDraw(float u, float v, Image *img, int time) override;
+    virtual void DrawMonsterPortrait(Rect rc, SpriteFrame *Portrait_Sprite, int Y_Offset) override;
 
 
-    virtual void MaskGameViewport();
+    virtual void MaskGameViewport() override;
 
     virtual void DrawMasked(float u, float v, class Image *img,
                             unsigned int color_dimming_level,
-                            unsigned __int16 mask);
-    virtual void DrawTextureGrayShade(float u, float v, class Image *a4);
-    virtual void DrawTransparentRedShade(float u, float v, class Image *a4);
+                            unsigned __int16 mask) override;
+    virtual void DrawTextureGrayShade(float u, float v, class Image *a4) override;
+    virtual void DrawTransparentRedShade(float u, float v, class Image *a4) override;
     virtual void DrawTransparentGreenShade(float u, float v,
-                                           class Image *pTexture);
+                                           class Image *pTexture) override;
     virtual void DrawFansTransparent(const RenderVertexD3D3 *vertices,
-                                     unsigned int num_vertices);
+                                     unsigned int num_vertices) override;
 
     virtual void DrawTextAlpha(int x, int y, unsigned char *font_pixels, int a5,
                                unsigned int uFontHeight, uint8_t *pPalette,
-                               bool present_time_transparency);
+                               bool present_time_transparency) override;
     virtual void DrawText(int uOutX, int uOutY, uint8_t *pFontPixels,
                           unsigned int uCharWidth, unsigned int uCharHeight,
                           uint8_t *pFontPalette, uint16_t uFaceColor,
-                          uint16_t uShadowColor);
+                          uint16_t uShadowColor) override;
 
     virtual void FillRectFast(unsigned int uX, unsigned int uY,
                               unsigned int uWidth, unsigned int uHeight,
-                              unsigned int uColor16);
+                              unsigned int uColor16) override;
 
-    virtual void DrawBuildingsD3D();
+    virtual void DrawBuildingsD3D() override;
 
-    virtual void DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID);
-    virtual void DrawOutdoorSkyD3D();
+    virtual void DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) override;
+    virtual void DrawOutdoorSkyD3D() override;
 
-    virtual void PrepareDecorationsRenderList_ODM();
+    virtual void PrepareDecorationsRenderList_ODM() override;
 
-    virtual void RenderTerrainD3D();
+    virtual void RenderTerrainD3D() override;
 
-    virtual bool AreRenderSurfacesOk();
+    virtual bool AreRenderSurfacesOk() override;
 
     unsigned short *MakeScreenshot(int width, int height);
-    virtual Image *TakeScreenshot(unsigned int width, unsigned int height);
+    virtual Image *TakeScreenshot(unsigned int width, unsigned int height) override;
     virtual void SaveScreenshot(const String &filename, unsigned int width,
-                                unsigned int height);
+                                unsigned int height) override;
     virtual void PackScreenshot(unsigned int width, unsigned int height,
                                 void *out_data, unsigned int data_size,
-                                unsigned int *screenshot_size);
-    virtual void SavePCXScreenshot();
+                                unsigned int *screenshot_size) override;
+    virtual void SavePCXScreenshot() override;
 
-    virtual int GetActorsInViewport(int pDepth);
+    virtual int GetActorsInViewport(int pDepth) override;
 
-    virtual void BeginLightmaps();
-    virtual void EndLightmaps();
-    virtual void BeginLightmaps2();
-    virtual void EndLightmaps2();
+    virtual void BeginLightmaps() override;
+    virtual void EndLightmaps() override;
+    virtual void BeginLightmaps2() override;
+    virtual void EndLightmaps2() override;
     virtual bool DrawLightmap(struct Lightmap *pLightmap,
-                              struct Vec3_float_ *pColorMult, float z_bias);
+                              struct Vec3_float_ *pColorMult, float z_bias) override;
 
-    virtual void BeginDecals();
-    virtual void EndDecals();
-    virtual void DrawDecal(struct Decal *pDecal, float z_bias);
+    virtual void BeginDecals() override;
+    virtual void EndDecals() override;
+    virtual void DrawDecal(struct Decal *pDecal, float z_bias) override;
 
     virtual void do_draw_debug_line_d3d(const RenderVertexD3D3 *pLineBegin,
                                         signed int sDiffuseBegin,
                                         const RenderVertexD3D3 *pLineEnd,
-                                        signed int sDiffuseEnd, float z_stuff);
+                                        signed int sDiffuseEnd, float z_stuff) override;
     virtual void DrawLines(const RenderVertexD3D3 *vertices,
-                           unsigned int num_vertices);
+                           unsigned int num_vertices) override;
 
     virtual void DrawSpecialEffectsQuad(const RenderVertexD3D3 *vertices,
-                                        Texture *texture);
+                                        Texture *texture) override;
 
     virtual void am_Blt_Chroma(Rect *pSrcRect, Point *pTargetPoint, int a3,
-                               int blend_mode);
+                               int blend_mode) override;
 
  public:
-    virtual void WritePixel16(int x, int y, uint16_t color);
+    virtual void WritePixel16(int x, int y, uint16_t color) override;
 
-    virtual unsigned int GetRenderWidth() const;
-    virtual unsigned int GetRenderHeight() const;
+    virtual unsigned int GetRenderWidth() const override;
+    virtual unsigned int GetRenderHeight() const override;
 
  protected:
     void DoRenderBillboards_D3D();

--- a/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -43,7 +43,7 @@ class RenderOpenGL : public RenderBase {
     virtual Texture *CreateTexture_PCXFromFile(const String &name);
     virtual Texture *CreateTexture_PCXFromIconsLOD(const String &name);
     virtual Texture *CreateTexture_PCXFromNewLOD(const String &name);
-    virtual Texture *CreateTexture_PCXFromLOD(void *pLOD, const String &name);
+    virtual Texture *CreateTexture_PCXFromLOD(LOD::File *pLOD, const String &name);
 
     virtual Texture *CreateTexture_Blank(unsigned int width, unsigned int height,
         IMAGE_FORMAT format, const void *pixels = nullptr);

--- a/Engine/Graphics/OpenGL/TextureOpenGL.h
+++ b/Engine/Graphics/OpenGL/TextureOpenGL.h
@@ -5,7 +5,7 @@ class TextureOpenGL : public Texture {
  public:
     int GetOpenGlTexture();
 
-    ~TextureOpenGL();
+    virtual ~TextureOpenGL();
 
  protected:
     friend class RenderOpenGL;

--- a/Engine/Graphics/Overlays.cpp
+++ b/Engine/Graphics/Overlays.cpp
@@ -86,6 +86,9 @@ void OtherOverlayList::DrawTurnBasedIcon(int a2) {
     } else if (pTurnEngine->turn_stage == TE_ATTACK) {  //группа атакует(ладонь)
         frame = pIconsFrameTable->GetFrame(uIconID_TurnStop,
             pEventTimer->uStartTime);
+    } else {
+        __debugbreak();
+        return;
     }
     // if ( render->pRenderD3D )
     render->DrawTextureAlphaNew(394 / 640.0f, 288 / 480.0f,

--- a/Engine/Graphics/PaletteManager.cpp
+++ b/Engine/Graphics/PaletteManager.cpp
@@ -184,7 +184,7 @@ void PaletteManager::SetColorChannelInfo(int uNumRBits, int uNumGBits,
 }
 
 //----- (00489BE0) --------------------------------------------------------
-void PaletteManager::CalcPalettes_LUT(int a2) {
+void PaletteManager::CalcPalettes_LUT(int paletteIdx) {
     PaletteManager *v2;  // esi@1
     // char *v3; // edi@1
     // signed int v4; // ebx@4
@@ -267,18 +267,18 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
     int v81;  // [sp+C5Ch] [bp+8h]@57
 
     v2 = this;
-    // v3 = (char *)pBaseColors[a2];
+    // v3 = (char *)pBaseColors[paletteIdx];
     if (pPalette_tintColor[0] || pPalette_tintColor[1] ||
         pPalette_tintColor[2]) {
         // v8 = 0;
         // i = 0;
 
         for (uint i = 0; i < 256; ++i)
-            RGB2HSV((pBaseColors[a2][i][0] + pPalette_tintColor[0]) /
+            RGB2HSV((pBaseColors[paletteIdx][i][0] + pPalette_tintColor[0]) /
                         (255.0f + 255.0f),  // Uninitialized memory access
-                    (pBaseColors[a2][i][1] + pPalette_tintColor[1]) /
+                    (pBaseColors[paletteIdx][i][1] + pPalette_tintColor[1]) /
                         (255.0f + 255.0f),
-                    (pBaseColors[a2][i][2] + pPalette_tintColor[2]) /
+                    (pBaseColors[paletteIdx][i][2] + pPalette_tintColor[2]) /
                         (255.0f + 255.0f),
                     &local_h[i], &local_s[i], &local_v[i]);
         // do
@@ -305,9 +305,9 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // while ( i <  );
     } else {
         for (uint i = 0; i < 256; ++i)
-            RGB2HSV(pBaseColors[a2][i][0] / 255.0f,
-                    pBaseColors[a2][i][1] / 255.0f,
-                    pBaseColors[a2][i][2] / 255.0f, &local_h[i], &local_s[i], &local_v[i]);
+            RGB2HSV(pBaseColors[paletteIdx][i][0] / 255.0f,
+                    pBaseColors[paletteIdx][i][1] / 255.0f,
+                    pBaseColors[paletteIdx][i][2] / 255.0f, &local_h[i], &local_s[i], &local_v[i]);
         /*v4 = 0;
         do
         {
@@ -324,9 +324,9 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         while ( v4 < 256 );*/
     }
 
-    // v69 = (PaletteManager *)((char *)v2 + 16384 * a2);
+    // v69 = (PaletteManager *)((char *)v2 + 16384 * paletteIdx);
     // v72 = 0;
-    // v73 = (int)pPalette1[a2];
+    // v73 = (int)pPalette1[paletteIdx];
     for (uint i = 0; i < 32; ++i) {
         // v20 = 0;
         // i = 0;
@@ -357,7 +357,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
             // v2->uNumTargetBBits) | ((unsigned __int32)a1 <<
             // (v2->uNumTargetBBits + v2->uNumTargetGBits)); v25 = v73; v73 += 2;
             // *(short *)v25 = v24;
-            pPalette1[a2][i][j] =
+            pPalette1[paletteIdx][i][j] =
                 (unsigned __int32)a3 |
                 ((unsigned __int32)a2a << v2->uNumTargetBBits) |
                 ((unsigned __int32)a1
@@ -410,7 +410,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
             // v19 = __OFSUB__(i, 256);
             // v18 = i - 256 < 0;
             // *v30 = v29;
-            field_199600_palettes[a2][i][j] =
+            field_199600_palettes[paletteIdx][i][j] =
                 (unsigned __int64)(signed __int64)a3 |
                 ((unsigned __int16)(signed __int64)a2a << v2->uNumTargetBBits) |
                 (unsigned __int16)((unsigned __int16)(signed __int64)a1
@@ -421,7 +421,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
     }
     // while ( v72 < 32 );
 
-    // v73 = (int)((char *)v2 + 512 * (a2 + 4875));   // field_261600[a2]
+    // v73 = (int)((char *)v2 + 512 * (paletteIdx + 4875));   // field_261600[paletteIdx]
     // v31 = 0;
     // i = 0;
     for (uint i = 0; i < 256; ++i) {
@@ -464,7 +464,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         v44 = v37 << (v39 + v2->uNumTargetGBits);
         // v73 += 2;
         // *(short *)v43 = v79 | ((short)v40 << v39) | (unsigned __int16)v44;
-        field_261600[a2][i] =
+        field_261600[paletteIdx][i] =
             v79 | ((unsigned short)v40 << v39) | (unsigned __int16)v44;
         // v31 = i + 4;
         // v19 = __OFSUB__(i + 4, 1024);
@@ -554,7 +554,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
             // v18 = i - 1024 < 0;
             // *(short *)result = v81 | ((short)v53 << uNumTargetBBits) | (v52 <<
             // v61);
-            field_D1600[a2][i][j] =
+            field_D1600[paletteIdx][i][j] =
                 v81 | ((short)v53 << uNumTargetBBits) | (v52 << v61);
             // if ( !(v18 ^ v19) )
             //  break;
@@ -744,7 +744,7 @@ int PaletteManager::LoadPalette(unsigned int uPaletteID) {
 // 48A3BC: using guessed type char var_386[766];
 
 //----- (0048A5A4) --------------------------------------------------------
-int PaletteManager::MakeBasePaletteLut(int idx, char *entries) {
+int PaletteManager::MakeBasePaletteLut(int uPaletteID, char *entries) {
     // PaletteManager *v3; // edi@1
     // signed int result; // eax@1
     // int *v5; // ecx@1
@@ -759,7 +759,7 @@ int PaletteManager::MakeBasePaletteLut(int idx, char *entries) {
     // v5 = this->pPaletteIDs;
 
     for (uint i = 0; i < 50; ++i)
-        if (pPaletteIDs[i] == idx) return i;
+        if (pPaletteIDs[i] == uPaletteID) return i;
 
     v6 = &pPaletteIDs[1];
     v7 = 1;
@@ -781,7 +781,7 @@ int PaletteManager::MakeBasePaletteLut(int idx, char *entries) {
     unsigned __int8 *dst = (unsigned __int8 *)pBaseColors[v7];
     for (uint i = 0; i < 768; ++i) dst[i] = entries[i];
 
-    pPaletteIDs[v7] = idx;
+    pPaletteIDs[v7] = uPaletteID;
     CalcPalettes_LUT(v7);
     return v7;
 }
@@ -800,57 +800,58 @@ void PaletteManager::RecalculateAll() {
     CalcPalettes_LUT(0);
 
     for (uint i = 1; i < 50; ++i)
-        if (pPaletteIDs[i]) CalcPalettes_LUT(i);
+        if (pPaletteIDs[i])
+            CalcPalettes_LUT(i);
 }
 
 //----- (0047BE67) --------------------------------------------------------
-unsigned __int16 *PaletteManager::Get(int a1) {
-    return (unsigned __int16 *)pPaletteManager->field_199600_palettes[a1];
+uint16_t *PaletteManager::Get(int paletteIdx) {
+    return &pPaletteManager->field_199600_palettes[paletteIdx][0][0];
 }
 
 //----- (0047BE72) --------------------------------------------------------
-unsigned __int16 *PaletteManager::Get_Mist_or_Red_LUT(int a1, int a2, char a3) {
+uint16_t *PaletteManager::Get_Mist_or_Red_LUT(int paletteIdx, int a2, char a3) {
     int v3;  // eax@4
 
     if (a3 & 2 || _4D864C_force_sw_render_rules && engine->config->AlterPalettes())
-        v3 = 32 * a1 + a2 + 3275;
+        v3 = 32 * paletteIdx + a2 + 3275;
     else
-        v3 = 32 * a1 + a2 + 1675;
+        v3 = 32 * paletteIdx + a2 + 1675;
     return (unsigned __int16 *)((char *)&pPaletteManager + 512 * v3);
 }
 // 4D864C: using guessed type char _4D864C_force_sw_render_rules;
 
 //----- (0041F50D) --------------------------------------------------------
-unsigned __int16 *PaletteManager::Get_Dark_or_Red_LUT(int a1, int a2, char a3) {
+uint16_t *PaletteManager::Get_Dark_or_Red_LUT(int paletteIdx, int a2, char a3) {
     int v3;  // eax@4
 
     if (a3 & 2 || _4D864C_force_sw_render_rules && engine->config->AlterPalettes())
-        v3 = 32 * a1 + a2 + 3275;
+        v3 = 32 * paletteIdx + a2 + 3275;
     else
-        v3 = 32 * a1 + a2 + 75;
+        v3 = 32 * paletteIdx + a2 + 75;
     return (unsigned __int16 *)((char *)&pPaletteManager + 512 * v3);
 }
 // 4D864C: using guessed type char _4D864C_force_sw_render_rules;
 
 //----- (0047C30E) --------------------------------------------------------
-unsigned __int16 *PaletteManager::_47C30E_get_palette(int a1, char a2) {
+uint16_t *PaletteManager::_47C30E_get_palette(int paletteIdx, char a2) {
     char *result;  // eax@4
 
     if (a2 & 2 || _4D864C_force_sw_render_rules && engine->config->AlterPalettes())
-        result = (char *)pPaletteManager->field_199600_palettes[a1];
+        result = (char *)pPaletteManager->field_199600_palettes[paletteIdx];
     else
-        result = (char *)pPaletteManager->field_D1600[a1];
+        result = (char *)pPaletteManager->field_D1600[paletteIdx];
     return (unsigned __int16 *)result;
 }
 
 //----- (0047C33F) --------------------------------------------------------
-unsigned __int16 *PaletteManager::_47C33F_get_palette(int a1, char a2) {
+uint16_t *PaletteManager::_47C33F_get_palette(int paletteIdx, char a2) {
     unsigned __int16 *result;  // eax@4
 
     if (a2 & 2 || _4D864C_force_sw_render_rules && engine->config->AlterPalettes())
-        result = (unsigned __int16 *)pPaletteManager->field_199600_palettes[a1];
+        result = (unsigned __int16 *)pPaletteManager->field_199600_palettes[paletteIdx];
     else
-        result = (unsigned __int16 *)pPaletteManager->pPalette1[a1];
+        result = (unsigned __int16 *)pPaletteManager->pPalette1[paletteIdx];
     return result;
 }
 

--- a/Engine/Graphics/PaletteManager.cpp
+++ b/Engine/Graphics/PaletteManager.cpp
@@ -706,8 +706,6 @@ int PaletteManager::MakeBasePaletteLut(int uPaletteID, char *entries) {
     // PaletteManager *v3; // edi@1
     // signed int result; // eax@1
     // int *v5; // ecx@1
-    int *v6;  // eax@4
-    int v7;  // esi@4
     // int v8; // eax@9
     // signed int v9; // ecx@9
     // int v10; // edx@9
@@ -716,16 +714,21 @@ int PaletteManager::MakeBasePaletteLut(int uPaletteID, char *entries) {
     // result = 0;
     // v5 = this->pPaletteIDs;
 
-    for (uint i = 0; i < 50; ++i)
-        if (pPaletteIDs[i] == uPaletteID) return i;
+    for (int i = 0; i < 50; ++i)
+        if (pPaletteIDs[i] == uPaletteID)
+            return i;
 
-    v6 = &pPaletteIDs[1];
-    v7 = 1;
-    while (*v6) {
-        ++v7;
-        v6 += 4;
-        if (v7 >= 50) return 0;
+    // Starting from 1 as palette at 0 is a grayscale palette
+    int freeIdx = 0;
+    for (int i = 1; i < 50; i++) {
+        if (pPaletteIDs[i] == 0) {
+            freeIdx = i;
+            break;
+        }
     }
+    if (freeIdx == 0)
+        return 0;
+
     /*v8 = (int)pBaseColors[v7];//(int)((char *)v3 + 768 * v7);
     v9 = 768;
     v10 = (int)(entries - v8);
@@ -736,12 +739,11 @@ int PaletteManager::MakeBasePaletteLut(int uPaletteID, char *entries) {
       --v9;
     }
     while ( v9 );*/
-    unsigned __int8 *dst = (unsigned __int8 *)pBaseColors[v7];
-    for (uint i = 0; i < 768; ++i) dst[i] = entries[i];
+    memcpy(&pBaseColors[freeIdx][0][0], entries, 768);
 
-    pPaletteIDs[v7] = uPaletteID;
-    CalcPalettes_LUT(v7);
-    return v7;
+    pPaletteIDs[freeIdx] = uPaletteID;
+    CalcPalettes_LUT(freeIdx);
+    return freeIdx;
 }
 
 // inlined

--- a/Engine/Graphics/PaletteManager.cpp
+++ b/Engine/Graphics/PaletteManager.cpp
@@ -82,7 +82,7 @@ bool HSV2RGB(float *redo, float *greeno, float *blueo, float hin, float sin, flo
 }
 
 //----- (0048A7AA) --------------------------------------------------------
-void RGB2HSV(float *outh, float *outs, float redin, float greenin, float bluein, float *outv) {
+void RGB2HSV(float redin, float greenin, float bluein, float* outh, float* outs, float *outv) {
     // RGB inputs 0-1
     if (redin > 1 || greenin > 1 || bluein > 1) __debugbreak();
 
@@ -246,9 +246,9 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
     unsigned int v60;  // eax@63
     char v61;          // cl@63
     // int result; // eax@63
-    float v63[256];  // [sp+1Ch] [bp-C38h]@5
-    float v64[256];  // [sp+41Ch] [bp-838h]@5
-    float a6[256];   // [sp+81Ch] [bp-438h]@5
+    float local_s[256];  // [sp+1Ch] [bp-C38h]@5
+    float local_h[256];  // [sp+41Ch] [bp-838h]@5
+    float local_v[256];   // [sp+81Ch] [bp-438h]@5
                      //  int v66; // [sp+C1Ch] [bp-38h]@43
     float v67;       // [sp+C20h] [bp-34h]@43
     float v68;       // [sp+C24h] [bp-30h]@43
@@ -274,19 +274,18 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // i = 0;
 
         for (uint i = 0; i < 256; ++i)
-            RGB2HSV(&v64[i], &v63[i],
-                    (pBaseColors[a2][i][0] + pPalette_tintColor[0]) /
+            RGB2HSV((pBaseColors[a2][i][0] + pPalette_tintColor[0]) /
                         (255.0f + 255.0f),  // Uninitialized memory access
                     (pBaseColors[a2][i][1] + pPalette_tintColor[1]) /
                         (255.0f + 255.0f),
                     (pBaseColors[a2][i][2] + pPalette_tintColor[2]) /
                         (255.0f + 255.0f),
-                    &a6[i]);
+                    &local_h[i], &local_s[i], &local_v[i]);
         // do
         //{
-        // v9 = (float *)((char *)v63 + v8);
-        // v10 = (float *)((char *)a6 + v8);
-        // v11 = (float *)((char *)v64 + v8);
+        // v9 = (float *)((char *)local_s + v8);
+        // v10 = (float *)((char *)local_v + v8);
+        // v11 = (float *)((char *)local_h + v8);
         // v12 = pPalette_tintColor[1];
         // LODWORD(v75) = pPalette_tintColor[2] + (unsigned __int8)v3[2];
         // v13 = pPalette_tintColor[1] + (unsigned __int8)v3[1];
@@ -296,7 +295,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // __int8)*v3 + pPalette_tintColor[0]; v16 = (double)((unsigned
         // __int8)v3[1] + pPalette_tintColor[1]) / 510.0f; v17 =
         // (double)((unsigned __int8)*v3 + pPalette_tintColor[0]) / 510.0f;
-        // RGB2HSV(&v64[i], &v63[i], v17, v16, v15, &a6[i]);
+        // RGB2HSV(v17, v16, v15, &local_h[i], &local_s[i], &local_v[i]);
         // v3 += 3;
         // v8 = i + 4;
         // v19 = __OFSUB__(i + 4, 1024);
@@ -306,9 +305,9 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // while ( i <  );
     } else {
         for (uint i = 0; i < 256; ++i)
-            RGB2HSV(&v64[i], &v63[i], pBaseColors[a2][i][0] / 255.0f,
+            RGB2HSV(pBaseColors[a2][i][0] / 255.0f,
                     pBaseColors[a2][i][1] / 255.0f,
-                    pBaseColors[a2][i][2] / 255.0f, &a6[i]);
+                    pBaseColors[a2][i][2] / 255.0f, &local_h[i], &local_s[i], &local_v[i]);
         /*v4 = 0;
         do
         {
@@ -318,7 +317,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
           v6 = (double)SLODWORD(v75) * 0.00392156862745098;
           LODWORD(v75) = (unsigned __int8)*v3;
           v7 = (double)SLODWORD(v75) * 0.00392156862745098;
-          RGB2HSV(&v64[v4], &v63[v4], v7, v6, v5, &a6[v4]);
+          RGB2HSV(v7, v6, v5, &local_h[v4], &local_s[v4], &local_v[v4]);
           ++v4;
           v3 += 3;
         }
@@ -334,11 +333,11 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // v71 = 1.0 - (double)v72 / 31.0f;
         // do
         for (uint j = 0; j < 256; ++j) {
-            v21 = a6[j] * (1.0f - i / 32.0f);
+            v21 = local_v[j] * (1.0f - i / 32.0f);
             if (v21 < 0.0) v21 = 0.0;
 
             // v22 = v21;
-            HSV2RGB(&a1, &a2a, &a3, v64[j], v63[j], v21);
+            HSV2RGB(&a1, &a2a, &a3, local_h[j], local_s[j], v21);
             v23 = v2->uNumTargetGBits;
             if (v23 == 6) {  // r5g6b5
                 a1 = a1 * 31.0;
@@ -381,7 +380,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // v71 = 1.0 - (double)v72 / 31.0f;
         // do
         for (uint j = 0; j < 256; ++j) {
-            v26 = a6[j] * (1.0 - i / 31.0f);
+            v26 = local_v[j] * (1.0 - i / 31.0f);
             if (v26 < 0.0) v26 = 0.0;
 
             // v27 = v26;
@@ -426,14 +425,14 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
     // v31 = 0;
     // i = 0;
     for (uint i = 0; i < 256; ++i) {
-        // v32 = (*(float *)((char *)a6 + v31) - 0.8) * 0.8387096774193549 +
+        // v32 = (*(float *)((char *)local_v + v31) - 0.8) * 0.8387096774193549 +
         // 0.8;
-        v32 = (a6[i] - 0.8f) * 0.8387096774193549 + 0.8;
+        v32 = (local_v[i] - 0.8f) * 0.8387096774193549 + 0.8;
         if (v32 < 0.0) v32 = 0.0;
 
         // v33 = v32;
-        // v34 = v63[i] * 0.7034339229968783;
-        HSV2RGB(&a1, &a2a, &a3, v64[i], v63[i] * 0.7034339229968783, v32);
+        // v34 = local_s[i] * 0.7034339229968783;
+        HSV2RGB(&a1, &a2a, &a3, local_h[i], local_s[i] * 0.7034339229968783, v32);
         v35 = v2->uNumTargetGBits;
         if (v35 == 6) {
             a1 = a1 * 31.0;
@@ -489,7 +488,7 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         mist_c = pPalette_mistColor[2] / 255.0f;
 
         float unused;
-        RGB2HSV(&v68, &v67, mist_a, mist_b, mist_c, &unused);
+        RGB2HSV(mist_a, mist_b, mist_c, &v68, &v67, &unused);
     }
 
     // v72 = 0;
@@ -499,11 +498,11 @@ void PaletteManager::CalcPalettes_LUT(int a2) {
         // v48 = 0;
         // for ( i = 0; ; v48 = i )
         for (uint j = 0; j < 256; ++j) {
-            v49 = v63[j];
+            v49 = local_s[j];
             if (v49 < 0.0) v49 = 0.0;
 
             // v50 = v49;
-            HSV2RGB(&a1, &a2a, &a3, v64[j], v49, a6[j]);
+            HSV2RGB(&a1, &a2a, &a3, local_h[j], v49, local_v[j]);
             // v51 = v2->uNumTargetGBits;
             if (v2->uNumTargetGBits == 6) {
                 a1 = a1 * 31.0;
@@ -707,7 +706,7 @@ int PaletteManager::LoadPalette(unsigned int uPaletteID) {
                     green = (double)tex.pPalette24[index + 1] / 255.0f;
                     // a3 = tex.pPalette24[v4 + 2];
                     blue = (double)tex.pPalette24[index + 2] / 255.0f;
-                    RGB2HSV(&v16, &v18, red, green, blue, &a6);
+                    RGB2HSV(red, green, blue, &v16, &v18, &a6);
 
                     v5 = a6 * 1.1;
                     if (v5 >= 0.0 && v5 >= 1.0) {
@@ -862,7 +861,7 @@ int ReplaceHSV(unsigned int uColor, float h_replace, float s_replace, float v_re
           b = (uColor & 0x000000FF) / 255.0f;
 
     float h, s, v;
-    RGB2HSV(&h, &s, r, g, b, &v);
+    RGB2HSV(r, g, b, &h, &s, &v);
 
     if (h_replace != -1.0) h = h_replace;
     if (s_replace != -1.0) s = s_replace;

--- a/Engine/Graphics/PaletteManager.h
+++ b/Engine/Graphics/PaletteManager.h
@@ -45,7 +45,7 @@ struct PaletteManager {
 };
 #pragma pack(pop)
 
-bool HSV2RGB(float *a1, float *a2, float *a3, float a4, float a5, float a6);
-void RGB2HSV(float *a1, float *a2, float a3, float a4, float a5, float *a6);
+bool HSV2RGB(float* redo, float* greeno, float* blueo, float hin, float sin, float vin);
+void RGB2HSV(float redin, float greenin, float bluein, float* outh, float* outs, float* outv);
 signed int ReplaceHSV(unsigned int uColor, float a2, float gamma, float a4);
 extern PaletteManager *pPaletteManager;

--- a/Engine/Graphics/PaletteManager.h
+++ b/Engine/Graphics/PaletteManager.h
@@ -9,20 +9,20 @@ struct PaletteManager {
 
     void SetMistColor(unsigned char r, unsigned char g, unsigned char b);
     int ResetNonTestLocked();
-    void CalcPalettes_LUT(int a2);
+    void CalcPalettes_LUT(int paletteIdx);
     int ResetNonLocked();
     int LoadPalette(unsigned int uPaletteID);
-    int MakeBasePaletteLut(int a2, char *entries);
+    int MakeBasePaletteLut(int uPaletteID, char *entries);
     void RecalculateAll();
     int LockAll();
     int LockTestAll();
     void SetColorChannelInfo(int uNumRBits, int uNumGBits, int uNumBBits);
 
-    static uint16_t *Get(int a1);
+    static uint16_t *Get(int paletteIdx);
     static uint16_t *Get_Mist_or_Red_LUT(int paletteIdx, int a2, char a3);
     static uint16_t *Get_Dark_or_Red_LUT(int paletteIdx, int a2, char a3);
-    static uint16_t *_47C30E_get_palette(int a1, char a2);
-    static uint16_t *_47C33F_get_palette(int a1, char a2);
+    static uint16_t *_47C30E_get_palette(int paletteIdx, char a2);
+    static uint16_t *_47C33F_get_palette(int paletteIdx, char a2);
 
     uint8_t pBaseColors[50][256][3];
     uint16_t pPalette1[50][32][256];

--- a/Engine/Graphics/RenderBase.h
+++ b/Engine/Graphics/RenderBase.h
@@ -18,17 +18,17 @@ class RenderBase : public IRender {
     ) : IRender(window, decal_builder, lightmap_builder, spellfx, particle_engine, vis, logger) {
     }
 
-    virtual bool Initialize();
+    virtual bool Initialize() override;
 
-    virtual void TransformBillboardsAndSetPalettesODM();
-    virtual void DrawSpriteObjects_ODM();
+    virtual void TransformBillboardsAndSetPalettesODM() override;
+    virtual void DrawSpriteObjects_ODM() override;
     virtual void MakeParticleBillboardAndPush(SoftwareBillboard *a2,
                                                   Texture *texture,
                                                   unsigned int uDiffuse,
-                                                  int angle);
+                                                  int angle) override;
 
-    virtual HWLTexture *LoadHwlBitmap(const std::string &name);
-    virtual HWLTexture *LoadHwlSprite(const std::string &name);
+    virtual HWLTexture *LoadHwlBitmap(const std::string &name) override;
+    virtual HWLTexture *LoadHwlSprite(const std::string &name) override;
 
  protected:
     unsigned int Billboard_ProbablyAddToListAndSortByZOrder(float z);

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -1570,8 +1570,8 @@ bool Vis::DoesRayIntersectBillboard(float fDepth,
 //----- (004C0D32) --------------------------------------------------------
 void Vis::PickIndoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
                                    Vis_SelectionFilter *filter) {
-    // This is not a very efficient implementations. One option would be to cache a list of all faces that have an
-    // action assigned, and iterate through it, instead of a list of all faces.
+    // This is not a very efficient implementation. Instead of iterating through all faces we could be iterating
+    // only through the ones that have an event assigned. That would require some work in IndoorLocation.
 
     for (size_t i = 0; i < pIndoor->uNumFaces; ++i) {
         BLVFace *pFace = &pIndoor->pFaces[i];

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -1570,31 +1570,19 @@ bool Vis::DoesRayIntersectBillboard(float fDepth,
 //----- (004C0D32) --------------------------------------------------------
 void Vis::PickIndoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
                                    Vis_SelectionFilter *filter) {
-    int result;          // eax@1
-    signed int pFaceID;  // esi@2
-    BLVFace *pFace;      // edi@4
-    // unsigned int v7; // eax@6
-    Vis_ObjectInfo *v8;  // eax@6
-    signed int i;        // [sp+18h] [bp-8h]@1
+    // This is not a very efficient implementations. One option would be to cache a list of all faces that have an
+    // action assigned, and iterate through it, instead of a list of all faces.
 
-    result = 0;
-    for (i = 0; i < (signed int)pBspRenderer->num_faces; ++i) {
-        pFaceID = pBspRenderer->faces[result].uFaceID;
-        if (pFaceID >= 0) {
-            if (pFaceID < (signed int)pIndoor->uNumFaces) {
-                pFace = &pIndoor->pFaces[pFaceID];
-                if (!pIndoorCameraD3D->IsCulled(&pIndoor->pFaces[pFaceID])) {
-                    if (is_part_of_selection(pFace, filter)) {
-                        v8 = DetermineFacetIntersection(
-                            pFace, PID(OBJECT_BModel, pFaceID), pick_depth);
-                        if (v8)
-                            list->AddObject(v8->object, v8->object_type,
-                                            v8->depth, v8->object_pid);
-                    }
-                }
+    for (size_t i = 0; i < pIndoor->uNumFaces; ++i) {
+        BLVFace *pFace = &pIndoor->pFaces[i];
+        if (!pIndoorCameraD3D->IsCulled(pFace)) {
+            if (is_part_of_selection(pFace, filter)) {
+                Vis_ObjectInfo *v8 = DetermineFacetIntersection(pFace, PID(OBJECT_BModel, i), pick_depth);
+                if (v8)
+                    list->AddObject(v8->object, v8->object_type,
+                                    v8->depth, v8->object_pid);
             }
         }
-        result = i + 1;
     }
 }
 

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -366,8 +366,8 @@ void Vis::PickOutdoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
     if (!pOutdoor) return;
 
     for (BSPModel &model : pOutdoor->pBModels) {
-        int reachable;
-        if (!IsBModelVisible(&model, &reachable)) {
+        bool reachable;
+        if (!IsBModelVisible(&model, fDepth, &reachable)) {
             continue;
         }
         if (!reachable && only_reachable) {
@@ -1601,8 +1601,8 @@ void Vis::PickIndoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
 void Vis::PickOutdoorFaces_Keyboard(float pick_depth, Vis_SelectionList *list,
                                     Vis_SelectionFilter *filter) {
     for (BSPModel &model : pOutdoor->pBModels) {
-        int reachable;
-        if (IsBModelVisible(&model, &reachable)) {
+        bool reachable;
+        if (IsBModelVisible(&model, pick_depth, &reachable)) {
             if (reachable) {
                 for (ODMFace &face : model.pFaces) {
                     if (is_part_of_selection(&face, filter)) {

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -317,11 +317,6 @@ void Vis::PickIndoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
     v5 = 0;
     v17 = 0;
 
-    // for (a1.flt_2C = 0.0; v17 < (signed int)pBspRenderer->num_faces; ++v17) {
-    //     pFaceID = pBspRenderer->faces[v5].uFaceID;
-    //     if (pFaceID >= 0) {
-    //        if (pFaceID < (signed int)pIndoor->uNumFaces) {
-
     for (a1.flt_2C = 0.0; v17 < (signed int)pIndoor->uNumFaces; ++v17) {
         BLVFace *face = &pIndoor->pFaces[/*pFaceID*/v17];
         if (is_part_of_selection(face, filter)) {
@@ -353,8 +348,7 @@ void Vis::PickIndoorFaces_Mouse(float fDepth, RenderVertexSoft *pRay,
         else
             face->uAttributes &= ~FACE_OUTLINED;
         face->uAttributes &= ~FACE_IsPicked;
-           // }
-       // }
+
         v5 = v17 + 1;
     }
 }

--- a/Engine/Graphics/Vis.h
+++ b/Engine/Graphics/Vis.h
@@ -68,7 +68,7 @@ struct Vis_SelectionList {
         uNumPointers++;
     }
 
-    void (***vdestructor_ptr)(Vis_SelectionList *, bool);
+    void (***vdestructor_ptr)(Vis_SelectionList *, bool) = nullptr;
     Vis_ObjectInfo object_pool[512] {};
     Vis_ObjectInfo* object_pointers[512] {};
     unsigned int uNumPointers;

--- a/Engine/IocContainer.cpp
+++ b/Engine/IocContainer.cpp
@@ -150,7 +150,6 @@ void IntegrityTest() {
                                                                              // already present from vec3
     // static_assert(sizeof(NPCData) == 0x4C, "Wrong type size");
     // static_assert(sizeof(NPCStats) == 0x17FFC, "Wrong type size");
-    // static_assert(sizeof(BspRenderer) == 0x53740, "Wrong type size");
     // static_assert(sizeof(ViewingParams) == 0x26C, "Wrong type size");
     // static_assert(sizeof(Bloodsplat) == 0x28, "Wrong type size");
     // static_assert(sizeof(BloodsplatContainer) == 0xA0C, "Wrong type size");

--- a/Engine/IocContainer.cpp
+++ b/Engine/IocContainer.cpp
@@ -150,6 +150,7 @@ void IntegrityTest() {
                                                                              // already present from vec3
     // static_assert(sizeof(NPCData) == 0x4C, "Wrong type size");
     // static_assert(sizeof(NPCStats) == 0x17FFC, "Wrong type size");
+    // static_assert(sizeof(BspRenderer) == 0x53740, "Wrong type size");
     // static_assert(sizeof(ViewingParams) == 0x26C, "Wrong type size");
     // static_assert(sizeof(Bloodsplat) == 0x28, "Wrong type size");
     // static_assert(sizeof(BloodsplatContainer) == 0xA0C, "Wrong type size");

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -1176,8 +1176,7 @@ Texture_MM7 *LODFile_IconsBitmaps::LoadTexturePtr(
     return &pTextures[id];
 }
 
-unsigned int LODFile_IconsBitmaps::LoadTexture(const String &pContainer,
-                                               enum TEXTURE_TYPE uTextureType) {
+unsigned int LODFile_IconsBitmaps::LoadTexture(const String &pContainer, enum TEXTURE_TYPE uTextureType) {
     for (uint i = 0; i < uNumLoadedFiles; ++i) {
         if (iequals(pContainer, pTextures[i].header.pName)) {
             return i;
@@ -1186,15 +1185,13 @@ unsigned int LODFile_IconsBitmaps::LoadTexture(const String &pContainer,
 
     Assert(uNumLoadedFiles < 1000);
 
-    if (LoadTextureFromLOD(&pTextures[uNumLoadedFiles], pContainer,
-                           uTextureType) == -1) {
+    if (LoadTextureFromLOD(&pTextures[uNumLoadedFiles], pContainer, uTextureType) == -1) {
         for (uint i = 0; i < uNumLoadedFiles; ++i) {
             if (iequals(pTextures[i].header.pName, "pending")) {
                 return i;
             }
         }
-        LoadTextureFromLOD(&pTextures[uNumLoadedFiles], "pending",
-                           uTextureType);
+        LoadTextureFromLOD(&pTextures[uNumLoadedFiles], "pending", uTextureType);
     }
 
     return uNumLoadedFiles++;

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -352,9 +352,10 @@ void LODFile_IconsBitmaps::ReleaseAll() {
     this->uNumLoadedFiles = 0;
 }
 
-unsigned int LODFile_IconsBitmaps::FindTextureByName(const char *pName) {
+unsigned int LODFile_IconsBitmaps::FindTextureByName(const String &pName) {
     for (uint i = 0; i < this->uNumLoadedFiles; i++) {
-        if (!_stricmp(this->pTextures[i].header.pName, pName)) return i;
+        if (iequals(this->pTextures[i].header.pName, pName))
+            return i;
     }
     return -1;
 }
@@ -1010,7 +1011,7 @@ void LODFile_IconsBitmaps::ReleaseHardwareTextures() {}
 void LODFile_IconsBitmaps::ReleaseLostHardwareTextures() {}
 
 int LODFile_IconsBitmaps::ReloadTexture(Texture_MM7 *pDst,
-                                        const char *pContainer, int mode) {
+                                        const String &pContainer, int mode) {
     unsigned int v7;  // ebx@6
     unsigned int v8;  // ecx@6
     int result;       // eax@7
@@ -1028,7 +1029,7 @@ int LODFile_IconsBitmaps::ReloadTexture(Texture_MM7 *pDst,
     Texture_MM7 *v6 = pDst;
     if (pDst->paletted_pixels && mode == 2 && pDst->pPalette24 &&
         (v7 = pDst->header.uTextureSize, fread(pDst, 1, 0x30u, File),
-         strcpy(pDst->header.pName, pContainer),
+         strncpy(pDst->header.pName, pContainer.c_str(), 16),
          v8 = pDst->header.uTextureSize, (int)v8 <= (int)v7)) {
         if (!pDst->header.uDecompressedSize ||
             this->_011BA4_debug_paletted_pixels_uncompressed) {
@@ -1054,7 +1055,7 @@ int LODFile_IconsBitmaps::ReloadTexture(Texture_MM7 *pDst,
 }
 
 int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
-                                             const char *pContainer,
+                                             const String &pContainer,
                                              enum TEXTURE_TYPE eTextureType) {
     int result;        // esi@14
     unsigned int v14;  // eax@21
@@ -1069,7 +1070,7 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
 
     TextureHeader *header = &pOutTex->header;
     fread(header, 1, sizeof(TextureHeader), pFile);
-    strncpy(header->pName, pContainer, 16);
+    strncpy(header->pName, pContainer.c_str(), 16);
     data_size -= sizeof(TextureHeader);
 
     // BITMAPS
@@ -1084,8 +1085,8 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
             ptr_011BB4 = new char[1000];
             memset(ptr_011BB4, 0, 1000);
         }
-        if (_strnicmp(pContainer, "wtrdr", 5)) {
-            if (_strnicmp(pContainer, "WtrTyl", 6)) {
+        if (!iequals(pContainer, "wtrdr")) {
+            if (!iequals(pContainer, "WtrTyl")) {
                 v14 = uNumLoadedFiles;
             } else {
                 render->hd_water_tile_id = uNumLoadedFiles;
@@ -1097,9 +1098,9 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
             result = 1;
         } else {
             char *temp_container;
-            temp_container = (char *)malloc(strlen(pContainer) + 2);
+            temp_container = (char *)malloc(pContainer.size() + 2);
             *temp_container = 104;  // 'h'
-            strcpy(temp_container + 1, pContainer);
+            strcpy(temp_container + 1, pContainer.c_str());
             result = 1;
             free((void *)temp_container);
         }
@@ -1167,7 +1168,7 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
 }
 
 Texture_MM7 *LODFile_IconsBitmaps::LoadTexturePtr(
-    const char *pContainer, enum TEXTURE_TYPE uTextureType) {
+    const String &pContainer, enum TEXTURE_TYPE uTextureType) {
     uint id = LoadTexture(pContainer, uTextureType);
 
     Assert(id != -1 && L"Texture_MM7 not found");
@@ -1175,10 +1176,10 @@ Texture_MM7 *LODFile_IconsBitmaps::LoadTexturePtr(
     return &pTextures[id];
 }
 
-unsigned int LODFile_IconsBitmaps::LoadTexture(const char *pContainer,
+unsigned int LODFile_IconsBitmaps::LoadTexture(const String &pContainer,
                                                enum TEXTURE_TYPE uTextureType) {
     for (uint i = 0; i < uNumLoadedFiles; ++i) {
-        if (!_stricmp(pContainer, pTextures[i].header.pName)) {
+        if (iequals(pContainer, pTextures[i].header.pName)) {
             return i;
         }
     }
@@ -1188,7 +1189,7 @@ unsigned int LODFile_IconsBitmaps::LoadTexture(const char *pContainer,
     if (LoadTextureFromLOD(&pTextures[uNumLoadedFiles], pContainer,
                            uTextureType) == -1) {
         for (uint i = 0; i < uNumLoadedFiles; ++i) {
-            if (!_stricmp(pTextures[i].header.pName, "pending")) {
+            if (iequals(pTextures[i].header.pName, "pending")) {
                 return i;
             }
         }

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -1057,7 +1057,7 @@ int LODFile_IconsBitmaps::ReloadTexture(Texture_MM7 *pDst,
 int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
                                              const String &pContainer,
                                              enum TEXTURE_TYPE eTextureType) {
-    int result;        // esi@14
+    //int result;        // esi@14
     unsigned int v14;  // eax@21
     // size_t v22;        // ST2C_4@29
     // const void *v23;   // ecx@29
@@ -1074,7 +1074,7 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
     data_size -= sizeof(TextureHeader);
 
     // BITMAPS
-    if ((header->pBits & 2) && strcmp(header->pName, "sptext01")) {
+    if ((header->pBits & 2) && pContainer != "sptext01") {
         if (!pHardwareSurfaces || !pHardwareTextures) {
             pHardwareSurfaces = new IDirectDrawSurface *[1000];
             memset(pHardwareSurfaces, 0, 1000 * sizeof(IDirectDrawSurface *));
@@ -1086,30 +1086,26 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
             memset(ptr_011BB4, 0, 1000);
         }
         if (!iequals(pContainer, "wtrdr")) {
-            if (!iequals(pContainer, "WtrTyl")) {
-                v14 = uNumLoadedFiles;
-            } else {
+            if (iequals(pContainer, "WtrTyl"))
                 render->hd_water_tile_id = uNumLoadedFiles;
-                v14 = uNumLoadedFiles;
-            }
+            v14 = uNumLoadedFiles;
             // result = render->LoadTexture(pContainer, pOutTex->palette_id1,
             // (void **)&pHardwareSurfaces[v14], (void
             // **)&pHardwareTextures[v14]);
-            result = 1;
+            //result = 1;
         } else {
             char *temp_container;
             temp_container = (char *)malloc(pContainer.size() + 2);
             *temp_container = 104;  // 'h'
             strcpy(temp_container + 1, pContainer.c_str());
-            result = 1;
+            //result = 1;
             free((void *)temp_container);
         }
-        return result;
+        //return result;
     }
 
     // ICONS
-    if (!header->uDecompressedSize ||
-        _011BA4_debug_paletted_pixels_uncompressed) {
+    if (!header->uDecompressedSize || _011BA4_debug_paletted_pixels_uncompressed) {
         if (header->uTextureSize > data_size) {
             assert(false);
         }

--- a/Engine/LOD.h
+++ b/Engine/LOD.h
@@ -127,17 +127,17 @@ class LODFile_IconsBitmaps : public LOD::File {
     LODFile_IconsBitmaps();
     virtual ~LODFile_IconsBitmaps();
     void SyncLoadedFilesCount();
-    unsigned int FindTextureByName(const char *pName);
+    unsigned int FindTextureByName(const String &pName);
     bool Load(const String &pFilename, const String &pFolderName);
     void ReleaseAll();
-    unsigned int LoadTexture(const char *pContainer,
+    unsigned int LoadTexture(const String &pContainer,
                              enum TEXTURE_TYPE uTextureType = TEXTURE_DEFAULT);
     struct Texture_MM7 *LoadTexturePtr(
-        const char *pContainer,
+        const String &pContainer,
         enum TEXTURE_TYPE uTextureType = TEXTURE_DEFAULT);
-    int LoadTextureFromLOD(struct Texture_MM7 *pOutTex, const char *pContainer,
+    int LoadTextureFromLOD(struct Texture_MM7 *pOutTex, const String &pContainer,
                            enum TEXTURE_TYPE eTextureType);
-    int ReloadTexture(struct Texture_MM7 *pDst, const char *pContainer,
+    int ReloadTexture(struct Texture_MM7 *pDst, const String &pContainer,
                       int mode);
     void ReleaseHardwareTextures();
     void ReleaseLostHardwareTextures();

--- a/Engine/MM7.h
+++ b/Engine/MM7.h
@@ -3,10 +3,10 @@
 
 typedef unsigned int uint;
 
-#define PID(type, id) (uint32_t)((((8 * (id))) | (type)) & 0xFFFF)  // packed id
+#define PID(type, id) (uint16_t)((((8 * (id))) | (type)) & 0xFFFF)  // packed id
 #define PID_TYPE(pid) (ObjectType)((pid)&7)          // extract type
 #define PID_ID(pid) (uint32_t)(((pid)&0xFFFF) >> 3)  // extract value
-#define PID_INVALID (-1)
+#define PID_INVALID (uint16_t)(-1)
 
 // typedef char _UNKNOWN;
 typedef unsigned int uint;

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -3383,7 +3383,6 @@ void Actor::DamageMonsterFromParty(signed int a1, unsigned int uActorID_Monster,
     unsigned __int16 v43;            // ax@132
     unsigned __int16 v45;            // ax@132
     // unsigned __int64 v46; // [sp+Ch] [bp-60h]@6
-    char *pPlayerName;                // [sp+18h] [bp-54h]@12
     signed int a4;                    // [sp+44h] [bp-28h]@1
     bool IsAdditionalDamagePossible;  // [sp+50h] [bp-1Ch]@1
     int v61;                          // [sp+58h] [bp-14h]@1

--- a/Engine/Objects/NPC.cpp
+++ b/Engine/Objects/NPC.cpp
@@ -1083,12 +1083,6 @@ void _4B4224_UpdateNPCTopics(int _this) {
     int num_menu_buttons;  // ebx@1
     int i;                 // ebp@5
                            // signed int v4; // ebp@9
-    int v6;                // eax@16
-    int v8;                // eax@21
-    int v10;               // eax@26
-    int v12;               // eax@31
-    int v14;               // eax@36
-    int v16;               // eax@41
     NPCData *v17;          // [sp+10h] [bp-4h]@4
 
     num_menu_buttons = 0;

--- a/Engine/OurMath.h
+++ b/Engine/OurMath.h
@@ -115,8 +115,6 @@ inline int bankersRounding<float>(const float &inValue) {
     return c.l;
 }
 
-#pragma push_macro("max")
-#undef max
 template <>
 inline int bankersRounding<double>(const double &inValue) {
     constexpr double maxValue = std::numeric_limits<int>::max();
@@ -129,6 +127,5 @@ inline int bankersRounding<double>(const double &inValue) {
     c.d = inValue + 6755399441055744.0;
     return c.l;
 }
-#pragma pop_macro("max")
 
 extern struct TrigTableLookup *TrigLUT;

--- a/Engine/Party.cpp
+++ b/Engine/Party.cpp
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <climits>
+#include <algorithm>
 
 #include "Engine/Engine.h"
 #include "Engine/Graphics/Outdoor.h"

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -113,6 +113,8 @@ void LoadGame(unsigned int uSlot) {
             serialization->Deserialize(pParty);
             free(serialization);
 
+            pParty->bTurnBasedModeOn = false;  // We always start in realtime after loading a game.
+
             for (size_t i = 0; i < 4; i++) {
                 Player *player = &pParty->pPlayers[i];
                 for (size_t j = 0; j < 5; j++) {

--- a/Engine/Serialization/LegacyImages.h
+++ b/Engine/Serialization/LegacyImages.h
@@ -771,8 +771,8 @@ struct BLVSector_MM7 {  // 0x74
 struct FontData_MM7 {
     FontData_MM7();
 
-    void Serialize(class FontData *);
-    void Deserialize(class FontData *, size_t size);
+    void Serialize(FontData *);
+    void Deserialize(FontData *, size_t size);
 
     uint8_t cFirstChar;  // 0
     uint8_t cLastChar;   // 1

--- a/Engine/Serialization/LegacyImages.h
+++ b/Engine/Serialization/LegacyImages.h
@@ -18,6 +18,17 @@
  * with original files.
  */
 
+struct BLVSector;
+struct NPCData;
+struct ItemGen;
+struct SpellBuff;
+struct Player;
+class UIAnimation;
+class Icon;
+struct OtherOverlayList;
+struct Timer;
+struct Party;
+
 /*   42 */
 #pragma pack(push, 1)
 struct SpriteFrame_MM6 {
@@ -95,8 +106,8 @@ struct TextureFrame_MM7 {
 struct NPCData_Image_MM7 {
     NPCData_Image_MM7();
 
-    void Serialize(struct NPCData *item);
-    void Deserialize(struct NPCData *item);
+    void Serialize(NPCData *item);
+    void Deserialize(NPCData *item);
 
     /* 00 */ int32_t pName;  // char *pName;
     /* 04 */ unsigned int uPortraitID;
@@ -124,8 +135,8 @@ struct NPCData_Image_MM7 {
 struct ItemGen_Image_MM7 {
     ItemGen_Image_MM7();
 
-    void Serialize(struct ItemGen *item);
-    void Deserialize(struct ItemGen *item);
+    void Serialize(ItemGen *item);
+    void Deserialize(ItemGen *item);
 
     /* 00 */ int uItemID;
     /* 04 */ int uEnchantmentType;
@@ -161,8 +172,8 @@ struct ItemGen_Image_MM7 {
 struct SpellBuff_Image_MM7 {
     SpellBuff_Image_MM7();
 
-    void Serialize(struct SpellBuff *item);
-    void Deserialize(struct SpellBuff *item);
+    void Serialize(SpellBuff *item);
+    void Deserialize(SpellBuff *item);
 
     /* 00 */ int64_t uExpireTime;
     /* 08 */ uint16_t uPower;
@@ -235,8 +246,8 @@ struct LloydBeacon_Image_MM7 {
 struct Player_Image_MM7 {
     Player_Image_MM7();
 
-    void Serialize(struct Player *);
-    void Deserialize(struct Player *);
+    void Serialize(Player *);
+    void Deserialize(Player *);
 
     /* 0000 */ int64_t pConditions[20];
     /* 00A0 */ uint64_t uExperience;
@@ -418,8 +429,8 @@ struct PartyTimeStruct_Image_MM7 {
 struct Party_Image_MM7 {
     Party_Image_MM7();
 
-    void Serialize(struct Party *);
-    void Deserialize(struct Party *);
+    void Serialize(Party *);
+    void Deserialize(Party *);
 
     /* 00000 */ int field_0;
     /* 00004 */ unsigned int uPartyHeight;
@@ -519,8 +530,8 @@ struct Party_Image_MM7 {
 struct Timer_Image_MM7 {
     Timer_Image_MM7();
 
-    void Serialize(struct Timer *);
-    void Deserialize(struct Timer *);
+    void Serialize(Timer *);
+    void Deserialize(Timer *);
 
     /* 00 */ uint32_t bReady;
     /* 04 */ uint32_t bPaused;
@@ -555,8 +566,8 @@ struct OtherOverlay_Image_MM7 {
 struct OtherOverlayList_Image_MM7 {
     OtherOverlayList_Image_MM7();
 
-    void Serialize(struct OtherOverlayList *);
-    void Deserialize(struct OtherOverlayList *);
+    void Serialize(OtherOverlayList *);
+    void Deserialize(OtherOverlayList *);
 
     /* 000 */ OtherOverlay_Image_MM7 pOverlays[50];
     /* 3E8 */ int field_3E8;
@@ -570,8 +581,8 @@ struct OtherOverlayList_Image_MM7 {
 struct IconFrame_MM7 {
     IconFrame_MM7();
 
-    void Serialize(class Icon *);
-    void Deserialize(class Icon *);
+    void Serialize(Icon *);
+    void Deserialize(Icon *);
 
     /* 000 */ char pAnimationName[12];
     /* 00C */ char pTextureName[12];
@@ -587,8 +598,8 @@ struct IconFrame_MM7 {
 struct UIAnimation_MM7 {
     UIAnimation_MM7();
 
-    void Serialize(class UIAnimation *);
-    void Deserialize(class UIAnimation *);
+    void Serialize(UIAnimation *);
+    void Deserialize(UIAnimation *);
 
     /* 000 */ uint16_t uIconID;
     /* 002 */ int16_t field_2;
@@ -720,8 +731,8 @@ struct Actor_MM7 {
 struct BLVSector_MM7 {  // 0x74
     BLVSector_MM7();
 
-    void Serialize(class BLVSector *);
-    void Deserialize(class BLVSector *);
+    void Serialize(BLVSector *);
+    void Deserialize(BLVSector *);
 
     int32_t field_0;
     uint16_t uNumFloors;

--- a/Engine/Spells/CastSpellInfo.cpp
+++ b/Engine/Spells/CastSpellInfo.cpp
@@ -68,7 +68,6 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
     // int *l;                // eax@556
     // int v295;              // edx@575
 
-    const char *v317;      // ecx@617
                            //  int v396; // eax@752
     __int16 v448;          // ax@864
     DDM_DLV_Header *v613;  // eax@1108

--- a/Engine/Strings.h
+++ b/Engine/Strings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <algorithm>
 #include <cstring>
 #ifndef _WINDOWS
 #include "Platform/Lin/Lin.h"
@@ -22,19 +23,16 @@ inline char *RemoveQuotes(char *str) {
 }
 
 inline bool iequals(std::string_view a, std::string_view b) {
-    return std::equal(a.begin(), a.end(), b.begin(), b.end(),
-        [](const unsigned char &a, const unsigned char &b) {
-            return tolower(a) == tolower(b);
-        }
-    );
+    return a.size() == b.size() && _strnicmp(a.data(), b.data(), a.size()) == 0;
 }
 
 inline bool iless(std::string_view a, std::string_view b) {
-    return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
-        [](const unsigned char &a, const unsigned char &b) {
-          return tolower(a) < tolower(b);
-        }
-    );
+    int result = _strnicmp(a.data(), b.data(), std::min(a.size(), b.size()));
+    if (result < 0)
+        return true;
+    if (result > 0)
+        return false;
+    return a.size() < b.size();
 }
 
 struct ILess {

--- a/GUI/UI/UIGame.cpp
+++ b/GUI/UI/UIGame.cpp
@@ -1046,7 +1046,6 @@ void GameUI_WritePointedObjectStatusString() {
     signed int v18b;
     signed int pickedObjectID = 0;     // ecx@63
     BLVFace *pFace;                    // eax@69
-    const char *pText;                 // ecx@79
     enum UIMessageType pMessageType2;  // esi@110
     enum UIMessageType pMessageType3;  // edx@117
     unsigned int pX;                   // [sp+D4h] [bp-Ch]@1
@@ -1098,6 +1097,7 @@ void GameUI_WritePointedObjectStatusString() {
                 }  // intentional fallthrough
             } else if (PID_TYPE(pickedObject.object_pid) == OBJECT_Decoration) {
                 if (!pLevelDecorations[pickedObjectID].uEventID) {
+                    const char* pText;                 // ecx@79
                     if (pLevelDecorations[pickedObjectID].IsInteractive())
                         pText = pNPCTopics[stru_5E4C90_MapPersistVars._decor_events
                                            [pLevelDecorations[pickedObjectID]._idx_in_stru123 -
@@ -1162,8 +1162,7 @@ void GameUI_WritePointedObjectStatusString() {
                     uLastPointedObjectID = 0;
                     return;
                 }
-                String pDisplayName = GetDisplayName(&pActors[pickedObjectID]).c_str();
-                GameUI_StatusBar_Set(pDisplayName.c_str());
+                GameUI_StatusBar_Set(GetDisplayName(&pActors[pickedObjectID]));
             } else if (mouse->uPointingObjectID == 0xFFFF) {
                 mouse->uPointingObjectID = 0;
             }
@@ -1414,7 +1413,7 @@ void GameUI_WritePointedObjectStatusString() {
                              requiredSkillpoints =
                              (pPlayers[uActiveCharacter]->pActiveSkills[pButton->msg_param]
                              & 0x3F) + 1;
-     
+
                              String str;
                              if (pPlayers[uActiveCharacter]->uSkillPoints <
                              requiredSkillpoints)      str =

--- a/GUI/UI/UIGuilds.cpp
+++ b/GUI/UI/UIGuilds.cpp
@@ -24,11 +24,7 @@
 using EngineIoc = Engine_::IocContainer;
 
 void GuildDialog() {
-    int textoffset;               // ecx@47
-    GUIButton *pButton;           // eax@49
     int pTextHeight;              // eax@55
-    unsigned __int16 pTextColor;  // ax@55
-    int textspacings;             // [sp+2D4h] [bp-18h]@1
     bool pSkillFlag;              // [sp+2DCh] [bp-10h]@35
     int dialogopts;               // [sp+2E0h] [bp-Ch]@35
 

--- a/GUI/UI/UIHouses.cpp
+++ b/GUI/UI/UIHouses.cpp
@@ -2800,9 +2800,7 @@ void sub_4B6478() {
     unsigned int v5;              // esi@5
     short *v6;                       // edi@6
     int all_text_height;          // eax@20
-    GUIButton *pButton;           // esi@27
     int pTextHeight;              // eax@29
-    unsigned __int16 pTextColor;  // ax@29
     int v27;                      // [sp-4h] [bp-80h]@8
     int v32;                      // [sp+6Ch] [bp-10h]@1
     int index;                    // [sp+74h] [bp-8h]@17

--- a/GUI/UI/UISaveLoad.cpp
+++ b/GUI/UI/UISaveLoad.cpp
@@ -74,7 +74,6 @@ GUIWindow_Save::GUIWindow_Save() :
                 strcpy(pSavegameHeader[i].pName, test.c_str());
             }
 
-//            pSavegameThumbnails[i] = Image::Create(new PCX_LOD_Raw_Loader(&pLODFile, "image.pcx"));
             pSavegameThumbnails[i] = render->CreateTexture_PCXFromLOD(&pLODFile, "image.pcx");
             if (pSavegameThumbnails[i]->GetWidth() == 0) {
                 pSavegameThumbnails[i]->Release();

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -466,7 +466,6 @@ void Game::EventLoop() {
     GUIButton *pButton;         // eax@578
     unsigned int v86;           // eax@583
     const char *v87;            // ecx@595
-    const char *v88;            // ecx@596
     unsigned int v90;           // eax@602
     int v91;                    // edx@605
     int v92;                    // eax@605

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2688,10 +2688,10 @@ void Game::GameLoop() {
         pMessageQueue_50CBD0->Flush();
 
         pPartyActionQueue->uNumActions = 0;
-        if (pParty->bTurnBasedModeOn) {
-            pTurnEngine->End(false);
-            pParty->bTurnBasedModeOn = false;
-        }
+
+        pTurnEngine->End(false);
+        pParty->bTurnBasedModeOn = false;  // Make sure turn engine and party turn based mode flag are in sync.
+
         DoPrepareWorld(bLoading, 1);
         pEventTimer->Resume();
         dword_6BE364_game_settings_1 |=

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2659,8 +2659,8 @@ void Game::EventLoop() {
 void Game::OnPressSpace() {
     engine->PickKeyboard(keyboardInputHandler->IsKeyboardPickingOutlineToggled(), &vis_sprite_filter_3, &vis_door_filter);
 
-    int pid = vis->get_picked_object_zbuf_val().object_pid;
-    if (pid != -1)
+    uint16_t pid = vis->get_picked_object_zbuf_val().object_pid;
+    if (pid != PID_INVALID)
         DoInteractionWithTopmostZObject(pid);
 }
 


### PR DESCRIPTION
Bugfixes:
* Savegame previews didn't draw in OpenGL, fixed it.
* Opening chests with space works the same as with a mouse (didn't consistently work with space before).
* Saving in turn-based mode and then loading that save while in realtime resulted in a crash.
* Can now shoot at monsters that are far away by clicking on them (used to work only up to a distance of 256 units).
* Using GL_REPEAT, fixing visual glitches.
* Activating clickable faces with space didn't work in dungeons.

Improvements:
* Using textures from LOD files instead of HWL. With some hacks to make textures with transparency look OK with OpenGL linear interpolation.

Refactoring:
* Replaced some of char* with String.
* Cleaned up PaletteManager code.
* Removed some dead code.
* Using more efficient case-comparison functions.
* Fixed some warnings.
* Added NOMINMAX, removed all the old min/max workarounds.
* Added override in several places, helped locate some dead code.