### PR TITLE
Replacing memcpy calls with assignments

### DIFF
--- a/Arcomage/Arcomage.cpp
+++ b/Arcomage/Arcomage.cpp
@@ -570,13 +570,12 @@ void ArcomageGame::PlaySound(unsigned int event_id) {
 }
 
 bool ArcomageGame::MsgLoop(int a1, ArcomageGame_InputMSG *a2) {
-    void *v2 = a2;
     pArcomageGame->field_0 = 0;
     pArcomageGame->stru1.am_input_type = 0;
 
     window->HandleSingleEvent();
 
-    memcpy(v2, &pArcomageGame->stru1, 0xCu);
+    *a2 = pArcomageGame->stru1;
     return pArcomageGame->stru1.am_input_type != 0;
 }
 

--- a/Engine/Graphics/BSPModel.cpp
+++ b/Engine/Graphics/BSPModel.cpp
@@ -17,12 +17,12 @@ struct ODMFace_MM7 {
     int zCalc2;
     int zCalc3;
     unsigned int uAttributes;
-    uint16_t pVertexIDs[20];
-    uint16_t pTextureUIDs[20];
-    uint16_t pTextureVIDs[20];
-    int16_t pXInterceptDisplacements[20];
-    int16_t pYInterceptDisplacements[20];
-    int16_t pZInterceptDisplacements[20];
+    std::array<uint16_t, 20> pVertexIDs;
+    std::array<int16_t, 20> pTextureUIDs;
+    std::array<int16_t, 20> pTextureVIDs;
+    std::array<int16_t, 20> pXInterceptDisplacements;
+    std::array<int16_t, 20> pYInterceptDisplacements;
+    std::array<int16_t, 20> pZInterceptDisplacements;
     int16_t uTextureID;
     int16_t sTextureDeltaU;
     int16_t sTextureDeltaV;
@@ -180,19 +180,16 @@ bool ODMFace::Deserialize(ODMFace_MM7 *mm7) {
 
     this->zCalc.Init(this->pFacePlaneOLD);
     this->uAttributes = mm7->uAttributes;
-    memcpy(this->pVertexIDs, mm7->pVertexIDs, sizeof(this->pVertexIDs));
-    memcpy(this->pTextureUIDs, mm7->pTextureUIDs, sizeof(this->pTextureUIDs));
-    memcpy(this->pTextureVIDs, mm7->pTextureVIDs, sizeof(this->pTextureVIDs));
-    memcpy(this->pXInterceptDisplacements, mm7->pXInterceptDisplacements,
-           sizeof(this->pXInterceptDisplacements));
-    memcpy(this->pYInterceptDisplacements, mm7->pYInterceptDisplacements,
-           sizeof(this->pYInterceptDisplacements));
-    memcpy(this->pZInterceptDisplacements, mm7->pZInterceptDisplacements,
-           sizeof(this->pZInterceptDisplacements));
+    this->pVertexIDs = mm7->pVertexIDs;
+    this->pTextureUIDs = mm7->pTextureUIDs;
+    this->pTextureVIDs = mm7->pTextureVIDs;
+    this->pXInterceptDisplacements = mm7->pXInterceptDisplacements;
+    this->pYInterceptDisplacements = mm7->pYInterceptDisplacements;
+    this->pZInterceptDisplacements = mm7->pZInterceptDisplacements;
     this->resource = nullptr;
     this->sTextureDeltaU = mm7->sTextureDeltaU;
     this->sTextureDeltaV = mm7->sTextureDeltaV;
-    memcpy(&this->pBoundingBox, &mm7->pBoundingBox, sizeof(this->pBoundingBox));
+    this->pBoundingBox = mm7->pBoundingBox;
     this->sCogNumber = mm7->sCogNumber;
     this->sCogTriggeredID = mm7->sCogTriggeredID;
     this->sCogTriggerType = mm7->sCogTriggerType;
@@ -239,6 +236,6 @@ bool ODMFace::Contains(const Vec3_int_ &pos, int model_idx, int override_plane) 
     BLVFace face;
     face.uAttributes = this->uAttributes;
     face.uNumVertices = this->uNumVertices;
-    face.pVertexIDs = const_cast<uint16_t *>(this->pVertexIDs);
+    face.pVertexIDs = const_cast<uint16_t *>(this->pVertexIDs.data());
     return face.Contains(pos, model_idx, override_plane);
 }

--- a/Engine/Graphics/BSPModel.cpp
+++ b/Engine/Graphics/BSPModel.cpp
@@ -172,7 +172,7 @@ void ODMFace::SetTexture(const std::string &filename) {
 }
 
 bool ODMFace::Deserialize(ODMFace_MM7 *mm7) {
-    memcpy(&this->pFacePlaneOLD, &mm7->pFacePlane, sizeof(this->pFacePlaneOLD));
+    this->pFacePlaneOLD = mm7->pFacePlane;
     this->pFacePlane.vNormal.x = this->pFacePlaneOLD.vNormal.x / 65536.0;
     this->pFacePlane.vNormal.y = this->pFacePlaneOLD.vNormal.y / 65536.0;
     this->pFacePlane.vNormal.z = this->pFacePlaneOLD.vNormal.z / 65536.0;

--- a/Engine/Graphics/BSPModel.h
+++ b/Engine/Graphics/BSPModel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <vector>
 #include <string>
 
@@ -141,12 +142,12 @@ struct ODMFace {
     struct Plane_int_ pFacePlaneOLD;
     PlaneZCalc_int64_ zCalc;
     uint32_t uAttributes = 0;
-    uint16_t pVertexIDs[20] {};
-    int16_t pTextureUIDs[20] {};
-    int16_t pTextureVIDs[20] {};
-    int16_t pXInterceptDisplacements[20] {};
-    int16_t pYInterceptDisplacements[20] {};
-    int16_t pZInterceptDisplacements[20] {};
+    std::array<uint16_t, 20> pVertexIDs = {{}};
+    std::array<int16_t, 20> pTextureUIDs = {{}};
+    std::array<int16_t, 20> pTextureVIDs = {{}};
+    std::array<int16_t, 20> pXInterceptDisplacements = {{}};
+    std::array<int16_t, 20> pYInterceptDisplacements = {{}};
+    std::array<int16_t, 20> pZInterceptDisplacements = {{}};
     void *resource = nullptr;  // __int16 uTextureID;
     std::string resourcename;
 

--- a/Engine/Graphics/ClippingFunctions.cpp
+++ b/Engine/Graphics/ClippingFunctions.cpp
@@ -198,7 +198,7 @@ bool stru9::ClipVertsToFrustumPlane(RenderVertexSoft* pInVertices, signed int pI
     while (true) {
         if (Vert1Inside) {
             // ++pVertices;
-            memcpy(pOutVertices, pLineStart, sizeof(RenderVertexSoft));
+            *pOutVertices = *pLineStart;
             ++*pOutNumVertices;
             // v10 = a5;
             pOutVertices++;

--- a/Engine/Graphics/Collisions.cpp
+++ b/Engine/Graphics/Collisions.cpp
@@ -369,7 +369,7 @@ void CollideOutdoorWithModels(bool ignore_ethereal) {
             face.uPolygonType = (PolygonType)mface.uPolygonType;
             face.uNumVertices = mface.uNumVertices;
             face.resource = mface.resource;
-            face.pVertexIDs = mface.pVertexIDs;
+            face.pVertexIDs = mface.pVertexIDs.data();
 
             if (face.Ethereal() || face.Portal()) // TODO: this doesn't respect ignore_ethereal parameter
                 continue;

--- a/Engine/Graphics/DecorationList.cpp
+++ b/Engine/Graphics/DecorationList.cpp
@@ -30,7 +30,7 @@ void DecorationList::FromFile(void *data_mm6, void *data_mm7, void *data_mm8) {
     DecorationDesc_mm6 *decors_mm6 = (DecorationDesc_mm6*)((char*)data_mm6 + 4);
     for (size_t i = 0; i < num_mm6_decs; ++i) {
         DecorationDesc decor;
-        memcpy(&decor, &decors_mm6[i], sizeof(DecorationDesc_mm6));
+        static_cast<DecorationDesc_mm6 &>(decor) = decors_mm6[i];
         decor.uColoredLightRed = 255;
         decor.uColoredLightGreen = 255;
         decor.uColoredLightBlue = 255;

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -346,20 +346,16 @@ void Render::RenderTerrainD3D() {  // New function
             // array_73D150[3].v = 1;
 
             // verts CCW - for testing
-            memcpy(&array_73D150[0], &pTerrainVertices[z * 128 + x],
-                sizeof(RenderVertexSoft));  // x, z
+            array_73D150[0] = pTerrainVertices[z * 128 + x];  // x, z
             array_73D150[0].u = 0;
             array_73D150[0].v = 0;
-            memcpy(&array_73D150[3], &pTerrainVertices[z * 128 + x + 1],
-                sizeof(RenderVertexSoft));  // x + 1, z
+            array_73D150[3] = pTerrainVertices[z * 128 + x + 1];  // x + 1, z
             array_73D150[3].u = 1;
             array_73D150[3].v = 0;
-            memcpy(&array_73D150[2], &pTerrainVertices[(z + 1) * 128 + x + 1],
-                sizeof(RenderVertexSoft));  // x + 1, z + 1
+            array_73D150[2] = pTerrainVertices[(z + 1) * 128 + x + 1];  // x + 1, z + 1
             array_73D150[2].u = 1;
             array_73D150[2].v = 1;
-            memcpy(&array_73D150[1], &pTerrainVertices[(z + 1) * 128 + x],
-                sizeof(RenderVertexSoft));  // x, z + 1
+            array_73D150[1] = pTerrainVertices[(z + 1) * 128 + x];  // x, z + 1
             array_73D150[1].u = 0;
             array_73D150[1].v = 1;
 
@@ -390,7 +386,7 @@ void Render::RenderTerrainD3D() {  // New function
             pTilePolygon->uBModelFaceID = 0;
             pTilePolygon->pid = (8 * (0 | (0 << 6))) | 6;
             for (unsigned int k = 0; k < pTilePolygon->uNumVertices; ++k) {
-                memcpy(&VertexRenderList[k], &array_73D150[k], sizeof(struct RenderVertexSoft));
+                VertexRenderList[k] = array_73D150[k];
                 VertexRenderList[k]._rhw = 1.0 / (array_73D150[k].vWorldViewPosition.x + 0.0000001000000011686097);
             }
 
@@ -425,25 +421,21 @@ void Render::RenderTerrainD3D() {  // New function
                 ///////////// triangle 1 - 1 2 3
 
                 // verts CCW - for testing
-                memcpy(&array_73D150[0], &pTerrainVertices[z * 128 + x],
-                    sizeof(RenderVertexSoft));  // x, z
+                array_73D150[0] = pTerrainVertices[z * 128 + x];  // x, z
                 array_73D150[0].u = 0;
                 array_73D150[0].v = 0;
-                memcpy(&array_73D150[2], &pTerrainVertices[z * 128 + x + 1],
-                    sizeof(RenderVertexSoft));  // x + 1, z
+                array_73D150[2] = pTerrainVertices[z * 128 + x + 1];  // x + 1, z
                 array_73D150[2].u = 1;
                 array_73D150[2].v = 0;
-                memcpy(&array_73D150[1], &pTerrainVertices[(z + 1) * 128 + x + 1],
-                    sizeof(RenderVertexSoft));  // x + 1, z + 1
+                array_73D150[1] = pTerrainVertices[(z + 1) * 128 + x + 1];  // x + 1, z + 1
                 array_73D150[1].u = 1;
                 array_73D150[1].v = 1;
-                // memcpy(&array_73D150[2], &pTerrainVertices[(z + 1) * 128 + x],
-                //    sizeof(RenderVertexSoft));  // x, z + 1
+                // array_73D150[2] = pTerrainVertices[(z + 1) * 128 + x]  // x, z + 1
                 // array_73D150[2].u = 0;
                 // array_73D150[2].v = 1;
 
                 for (unsigned int k = 0; k < pTilePolygon->uNumVertices; ++k) {
-                    memcpy(&VertexRenderList[k], &array_73D150[k], sizeof(struct RenderVertexSoft));
+                    VertexRenderList[k] = array_73D150[k];
                     VertexRenderList[k]._rhw = 1.0 / (array_73D150[k].vWorldViewPosition.x + 0.0000001000000011686097);
                 }
 
@@ -521,25 +513,21 @@ void Render::RenderTerrainD3D() {  // New function
                 ///////////// triangle 2  0 1 3
                 {
                     // verts CCW - for testing
-                    memcpy(&array_73D150[0], &pTerrainVertices[z * 128 + x],
-                        sizeof(RenderVertexSoft));  // x, z
+                    array_73D150[0] = pTerrainVertices[z * 128 + x];  // x, z
                     array_73D150[0].u = 0;
                     array_73D150[0].v = 0;
-                    // memcpy(&array_73D150[2], &pTerrainVertices[z * 128 + x + 1],
-                    //    sizeof(RenderVertexSoft));  // x + 1, z
+                    // array_73D150[2] = pTerrainVertices[z * 128 + x + 1]  // x + 1, z
                     // array_73D150[2].u = 1;
                     // array_73D150[2].v = 0;
-                    memcpy(&array_73D150[2], &pTerrainVertices[(z + 1) * 128 + x + 1],
-                        sizeof(RenderVertexSoft));  // x + 1, z + 1
+                    array_73D150[2] = pTerrainVertices[(z + 1) * 128 + x + 1];  // x + 1, z + 1
                     array_73D150[2].u = 1;
                     array_73D150[2].v = 1;
-                    memcpy(&array_73D150[1], &pTerrainVertices[(z + 1) * 128 + x],
-                        sizeof(RenderVertexSoft));  // x, z + 1
+                    array_73D150[1] = pTerrainVertices[(z + 1) * 128 + x];  // x, z + 1
                     array_73D150[1].u = 0;
                     array_73D150[1].v = 1;
 
                     for (unsigned int k = 0; k < pTilePolygon->uNumVertices; ++k) {
-                        memcpy(&VertexRenderList[k], &array_73D150[k], sizeof(struct RenderVertexSoft));
+                        VertexRenderList[k] = array_73D150[k];
                         VertexRenderList[k]._rhw = 1.0 / (array_73D150[k].vWorldViewPosition.x + 0.0000001000000011686097);
                     }
 
@@ -693,8 +681,7 @@ void Render::RenderTerrainD3D() {  // New function
 }
 
 void Render::DrawBorderTiles(struct Polygon *poly) {
-    struct Polygon poly_clone;
-    memcpy(&poly_clone, poly, sizeof(poly_clone));
+    struct Polygon poly_clone = *poly;
     poly_clone.texture = this->hd_water_tile_anim[this->hd_water_current_frame];
 
     pRenderD3D->pDevice->SetRenderState(D3DRENDERSTATE_ZWRITEENABLE, false);
@@ -3433,9 +3420,7 @@ void Render::DrawBuildingsD3D() {
                 poly->pid = PID(OBJECT_BModel, (face.index | (model.index << 6)));
                 for (int vertex_id = 0; vertex_id < face.uNumVertices;
                      ++vertex_id) {
-                    memcpy(&VertexRenderList[vertex_id],
-                           &array_73D150[vertex_id],
-                           sizeof(VertexRenderList[vertex_id]));
+                    VertexRenderList[vertex_id] = array_73D150[vertex_id];
                     VertexRenderList[vertex_id]._rhw =
                         1.0 / (array_73D150[vertex_id].vWorldViewPosition.x +
                                0.0000001);
@@ -3678,9 +3663,8 @@ void Render::do_draw_debug_line_d3d(const RenderVertexD3D3 *pLineBegin,
                                     const RenderVertexD3D3 *pLineEnd,
                                     signed int sDiffuseEnd, float z_stuff) {
     RenderVertexD3D3 vertices[2];  // [sp+8h] [bp-40h]@2
-
-    memcpy(&vertices[0], pLineBegin, sizeof(vertices[0]));
-    memcpy(&vertices[1], pLineEnd, sizeof(vertices[1]));
+    vertices[0] = *pLineBegin;
+    vertices[1] = *pLineEnd;
 
     vertices[0].pos.z = 0.001 - z_stuff;
     vertices[1].pos.z = 0.001 - z_stuff;
@@ -4304,7 +4288,7 @@ void Render::DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) {  /
         uint i = 0;
         for (v78 = pSkyPolygon.uNumVertices; v78; --v78) {
             ++HEXRAYS_LODWORD(v73);
-            memcpy(&VertexRenderList[i], &array_507D30[i], sizeof(RenderVertexSoft));
+            VertexRenderList[i] = array_507D30[i];
             HEXRAYS_LODWORD(v76) += 48;
             if (v28 <= array_507D30[i].vWorldViewProjY ||
                 v28 >= array_507D30[i + 1].vWorldViewProjY) {
@@ -4441,7 +4425,7 @@ LABEL_40:
             --HEXRAYS_HIDWORD(v69)) {
             if (v48 >= VertexRenderList[i].vWorldViewProjY) {
                 ++i;
-                memcpy(&array_507D30[i], &VertexRenderList[i], sizeof(RenderVertexSoft));
+                array_507D30[i] = VertexRenderList[i];
             }
         }
     }
@@ -4453,7 +4437,7 @@ LABEL_40:
         for (v80 = v73; v80 != 0.0; --HEXRAYS_LODWORD(v80)) {
             if (v51 <= VertexRenderList[pNumVertices].vWorldViewProjY) {
                 ++pNumVertices;
-                memcpy(&array_507D30[pNumVertices], &VertexRenderList[pNumVertices], sizeof(RenderVertexSoft));
+                array_507D30[pNumVertices] = VertexRenderList[pNumVertices];
             }
         }
     }

--- a/Engine/Graphics/Direct3D/RenderD3D.cpp
+++ b/Engine/Graphics/Direct3D/RenderD3D.cpp
@@ -50,7 +50,7 @@ HRESULT __stdcall D3DDeviceEnumerator(
         strcpy(a6->pInfo[v7].pDescription, lpDeviceDesc);
 
         a6->pInfo[v7].pGUID = new GUID;
-        memcpy(a6->pInfo[v7].pGUID, lpGUID, 0x10);
+        *a6->pInfo[v7].pGUID = *lpGUID;
 
         a6->pInfo[v7].pDriverName = strdup(a6->ptr_4->pDriverName);
         a6->pInfo[v7].pDeviceDesc = strdup(a6->ptr_4->pDeviceDesc);
@@ -58,7 +58,7 @@ HRESULT __stdcall D3DDeviceEnumerator(
 
         if (a6->ptr_4->pGUID) {
             a6->pInfo[v7].pDirectDrawGUID = new GUID;
-            memcpy(a6->pInfo[v7].pDirectDrawGUID, a6->ptr_4->pGUID, 0x10);
+            *a6->pInfo[v7].pDirectDrawGUID = *a6->ptr_4->pGUID;
         } else {
             a6->pInfo[v7].pDirectDrawGUID = 0;
         }
@@ -90,7 +90,7 @@ int __stdcall RenderD3D__DeviceEnumerator(GUID *lpGUID, const char *lpDevDesc,
     strcpy(v20.pDeviceDesc, lpDevDesc);
     if (lpGUID) {
         v20.pGUID = new GUID;
-        memcpy(v20.pGUID, lpGUID, 0x10);
+        *v20.pGUID = *lpGUID;
     } else {
         v20.pGUID = 0;
     }
@@ -163,11 +163,11 @@ HRESULT __stdcall D3DZBufferFormatEnumerator(DDPIXELFORMAT *Src,
                                              DDPIXELFORMAT *Dst) {
     if (Src->dwFlags & (0x400 | 0x2000)) {
         if (Src->dwRGBBitCount == 16 && !Src->dwRBitMask) {
-            memcpy(Dst, Src, sizeof(DDPIXELFORMAT));
+            *Dst = *Src;
             return 0;
         }
         if (!Dst->dwSize) {
-            memcpy(Dst, Src, sizeof(DDPIXELFORMAT));
+            *Dst = *Src;
             return 1;
         }
     }

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -70,8 +70,8 @@ std::array<const char *, 11> _4E6BDC_loc_names = {
     "mdt09.blv", "mdt15.blv", "mdt11.blv"};
 
 bool BLVFace::Deserialize(BLVFace_MM7 *data) {
-    memcpy(&this->pFacePlane, &data->pFacePlane, sizeof(this->pFacePlane));
-    memcpy(&this->pFacePlane_old, &data->pFacePlane_old, sizeof(this->pFacePlane_old));
+    this->pFacePlane = data->pFacePlane;
+    this->pFacePlane_old = data->pFacePlane_old;
     this->zCalc.Init(this->pFacePlane_old);
     this->uAttributes = data->uAttributes;
     this->pVertexIDs = (uint16_t *)data->pVertexIDs;
@@ -84,7 +84,7 @@ bool BLVFace::Deserialize(BLVFace_MM7 *data) {
     // unsigned __int16  uBitmapID;
     this->uSectorID = data->uSectorID;
     this->uBackSectorID = data->uBackSectorID;
-    memcpy(&this->pBounding, &data->pBounding, sizeof(this->pBounding));
+    this->pBounding = data->pBounding;
     this->uPolygonType = (PolygonType)data->uPolygonType;
     this->uNumVertices = data->uNumVertices;
     this->field_5E = data->field_5E;
@@ -409,29 +409,18 @@ void IndoorLocation::Draw() {
 
 //----- (004C0EF2) --------------------------------------------------------
 void BLVFace::FromODM(ODMFace *face) {
-    this->pFacePlane_old.vNormal.x = face->pFacePlaneOLD.vNormal.x;
-    this->pFacePlane_old.vNormal.y = face->pFacePlaneOLD.vNormal.y;
-    this->pFacePlane_old.vNormal.z = face->pFacePlaneOLD.vNormal.z;
-    this->pFacePlane_old.dist = face->pFacePlaneOLD.dist;
-    this->pFacePlane.vNormal.x = face->pFacePlane.vNormal.x;
-    this->pFacePlane.vNormal.y = face->pFacePlane.vNormal.y;
-    this->pFacePlane.vNormal.z = face->pFacePlane.vNormal.z;
-    this->pFacePlane.dist = face->pFacePlane.dist;
+    this->pFacePlane_old = face->pFacePlaneOLD;
+    this->pFacePlane = face->pFacePlane;
     this->uAttributes = face->uAttributes;
-    this->pBounding.x1 = face->pBoundingBox.x1;
-    this->pBounding.y1 = face->pBoundingBox.y1;
-    this->pBounding.z1 = face->pBoundingBox.z1;
-    this->pBounding.x2 = face->pBoundingBox.x2;
-    this->pBounding.y2 = face->pBoundingBox.y2;
-    this->pBounding.z2 = face->pBoundingBox.z2;
+    this->pBounding = face->pBoundingBox;
     this->zCalc = face->zCalc;
-    this->pXInterceptDisplacements = face->pXInterceptDisplacements;
-    this->pYInterceptDisplacements = face->pYInterceptDisplacements;
-    this->pZInterceptDisplacements = face->pZInterceptDisplacements;
+    this->pXInterceptDisplacements = face->pXInterceptDisplacements.data();
+    this->pYInterceptDisplacements = face->pYInterceptDisplacements.data();
+    this->pZInterceptDisplacements = face->pZInterceptDisplacements.data();
     this->uPolygonType = (PolygonType)face->uPolygonType;
     this->uNumVertices = face->uNumVertices;
     this->resource = face->resource;
-    this->pVertexIDs = face->pVertexIDs;
+    this->pVertexIDs = face->pVertexIDs.data();
 }
 
 //----- (004B0A25) --------------------------------------------------------

--- a/Engine/Graphics/LightmapBuilder.cpp
+++ b/Engine/Graphics/LightmapBuilder.cpp
@@ -513,7 +513,7 @@ bool LightmapBuilder::ApplyLights(LightsData *pLights, stru154 *FacePlane, unsig
     a9 = FaceVertexList;
     if (a6) {
         for (uint i = 0; i < uNumVertices; ++i)
-            memcpy(&static_69B140[i], FaceVertexList + i, sizeof(RenderVertexSoft));
+            static_69B140[i] = FaceVertexList[i];
 
         if (pCamera3D->CullVertsToPlane(FacePlane, static_69B140, &uNumVertices) == 1) {
             if (!uNumVertices) return false;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1915,20 +1915,16 @@ void RenderOpenGL::RenderTerrainD3D() {
             pTilePolygon->sTextureDeltaU = 0;
             pTilePolygon->sTextureDeltaV = 0;
 
-            memcpy(&array_73D150[0], &pTerrainVertices[z * 128 + x],
-                sizeof(RenderVertexSoft));  // x, z
+            array_73D150[0] = pTerrainVertices[z * 128 + x];  // x, z
             array_73D150[0].u = 0;
             array_73D150[0].v = 0;
-            memcpy(&array_73D150[3], &pTerrainVertices[z * 128 + x + 1],
-                sizeof(RenderVertexSoft));  // x + 1, z
+            array_73D150[3] = pTerrainVertices[z * 128 + x + 1];  // x + 1, z
             array_73D150[3].u = 1;
             array_73D150[3].v = 0;
-            memcpy(&array_73D150[2], &pTerrainVertices[(z + 1) * 128 + x + 1],
-                sizeof(RenderVertexSoft));  // x + 1, z + 1
+            array_73D150[2] = pTerrainVertices[(z + 1) * 128 + x + 1];  // x + 1, z + 1
             array_73D150[2].u = 1;
             array_73D150[2].v = 1;
-            memcpy(&array_73D150[1], &pTerrainVertices[(z + 1) * 128 + x],
-                sizeof(RenderVertexSoft));  // x, z + 1
+            array_73D150[1] = pTerrainVertices[(z + 1) * 128 + x];  // x, z + 1
             array_73D150[1].u = 0;
             array_73D150[1].v = 1;
 
@@ -1949,7 +1945,7 @@ void RenderOpenGL::RenderTerrainD3D() {
             pTilePolygon->uBModelFaceID = 0;
             pTilePolygon->pid = (8 * (0 | (0 << 6))) | 6;
             for (unsigned int k = 0; k < pTilePolygon->uNumVertices; ++k) {
-                memcpy(&VertexRenderList[k], &array_73D150[k], sizeof(struct RenderVertexSoft));
+                VertexRenderList[k] = array_73D150[k];
                 VertexRenderList[k]._rhw = 1.0 / (array_73D150[k].vWorldViewPosition.x + 0.0000001000000011686097);
             }
 
@@ -1981,16 +1977,13 @@ void RenderOpenGL::RenderTerrainD3D() {
                 ///////////// triangle 1 - 1 2 3
 
                 // verts CCW - for testing
-                memcpy(&array_73D150[0], &pTerrainVertices[z * 128 + x],
-                    sizeof(RenderVertexSoft));  // x, z
+                array_73D150[0] = pTerrainVertices[z * 128 + x];  // x, z
                 array_73D150[0].u = 0;
                 array_73D150[0].v = 0;
-                memcpy(&array_73D150[2], &pTerrainVertices[z * 128 + x + 1],
-                    sizeof(RenderVertexSoft));  // x + 1, z
+                array_73D150[2] = pTerrainVertices[z * 128 + x + 1];  // x + 1, z
                 array_73D150[2].u = 1;
                 array_73D150[2].v = 0;
-                memcpy(&array_73D150[1], &pTerrainVertices[(z + 1) * 128 + x + 1],
-                    sizeof(RenderVertexSoft));  // x + 1, z + 1
+                array_73D150[1] = pTerrainVertices[(z + 1) * 128 + x + 1];  // x + 1, z + 1
                 array_73D150[1].u = 1;
                 array_73D150[1].v = 1;
                 // memcpy(&array_73D150[2], &pTerrainVertices[(z + 1) * 128 + x],
@@ -1999,7 +1992,7 @@ void RenderOpenGL::RenderTerrainD3D() {
                 // array_73D150[2].v = 1;
 
                 for (unsigned int k = 0; k < pTilePolygon->uNumVertices; ++k) {
-                    memcpy(&VertexRenderList[k], &array_73D150[k], sizeof(struct RenderVertexSoft));
+                    VertexRenderList[k] = array_73D150[k];
                     VertexRenderList[k]._rhw = 1.0 / (array_73D150[k].vWorldViewPosition.x + 0.0000001000000011686097);
                 }
 

--- a/Engine/Graphics/PortalFunctions.cpp
+++ b/Engine/Graphics/PortalFunctions.cpp
@@ -73,56 +73,20 @@ void stru10::_49CE9E(BLVFace *pFace, RenderVertexSoft *pVertices,
     stru10::CalcPolygonLimits(pFace, pLimits);
 
     if (pFace->uAttributes & FACE_XY_PLANE) {
-        memcpy(&pOutLimits[0],
-               &pVertices[_49CE9E_sub0_x(pVertices, uNumVertices,
-                                         pLimits[0].vWorldPosition.x)],
-               0x30);
-        memcpy(&pOutLimits[2],
-               &pVertices[_49CE9E_sub0_x(pVertices, uNumVertices,
-                                         pLimits[2].vWorldPosition.x)],
-               0x30);
-        memcpy(&pOutLimits[1],
-               &pVertices[_49CE9E_sub0_y(pVertices, uNumVertices,
-                                         pLimits[1].vWorldPosition.y)],
-               0x30);
-        memcpy(&pOutLimits[3],
-               &pVertices[_49CE9E_sub0_y(pVertices, uNumVertices,
-                                         pLimits[3].vWorldPosition.y)],
-               0x30);
+        pOutLimits[0] = pVertices[_49CE9E_sub0_x(pVertices, uNumVertices, pLimits[0].vWorldPosition.x)];
+        pOutLimits[2] = pVertices[_49CE9E_sub0_x(pVertices, uNumVertices, pLimits[2].vWorldPosition.x)];
+        pOutLimits[1] = pVertices[_49CE9E_sub0_y(pVertices, uNumVertices, pLimits[1].vWorldPosition.y)];
+        pOutLimits[3] = pVertices[_49CE9E_sub0_y(pVertices, uNumVertices, pLimits[3].vWorldPosition.y)];
     } else if (pFace->uAttributes & FACE_XZ_PLANE) {
-        memcpy(&pOutLimits[0],
-               &pVertices[_49CE9E_sub0_x(pVertices, uNumVertices,
-                                         pLimits[0].vWorldPosition.x)],
-               0x30);
-        memcpy(&pOutLimits[2],
-               &pVertices[_49CE9E_sub0_x(pVertices, uNumVertices,
-                                         pLimits[2].vWorldPosition.x)],
-               0x30);
-        memcpy(&pOutLimits[1],
-               &pVertices[_49CE9E_sub0_z(pVertices, uNumVertices,
-                                         pLimits[1].vWorldPosition.z)],
-               0x30);
-        memcpy(&pOutLimits[3],
-               &pVertices[_49CE9E_sub0_z(pVertices, uNumVertices,
-                                         pLimits[3].vWorldPosition.z)],
-               0x30);
+        pOutLimits[0] = pVertices[_49CE9E_sub0_x(pVertices, uNumVertices, pLimits[0].vWorldPosition.x)];
+        pOutLimits[2] = pVertices[_49CE9E_sub0_x(pVertices, uNumVertices, pLimits[2].vWorldPosition.x)];
+        pOutLimits[1] = pVertices[_49CE9E_sub0_z(pVertices, uNumVertices, pLimits[1].vWorldPosition.z)];
+        pOutLimits[3] = pVertices[_49CE9E_sub0_z(pVertices, uNumVertices, pLimits[3].vWorldPosition.z)];
     } else if (pFace->uAttributes & FACE_YZ_PLANE) {
-        memcpy(&pOutLimits[0],
-               &pVertices[_49CE9E_sub0_y(pVertices, uNumVertices,
-                                         pLimits[0].vWorldPosition.y)],
-               0x30);
-        memcpy(&pOutLimits[2],
-               &pVertices[_49CE9E_sub0_y(pVertices, uNumVertices,
-                                         pLimits[2].vWorldPosition.y)],
-               0x30);
-        memcpy(&pOutLimits[1],
-               &pVertices[_49CE9E_sub0_z(pVertices, uNumVertices,
-                                         pLimits[1].vWorldPosition.z)],
-               0x30);
-        memcpy(&pOutLimits[3],
-               &pVertices[_49CE9E_sub0_z(pVertices, uNumVertices,
-                                         pLimits[3].vWorldPosition.z)],
-               0x30);
+        pOutLimits[0] = pVertices[_49CE9E_sub0_y(pVertices, uNumVertices, pLimits[0].vWorldPosition.y)];
+        pOutLimits[2] = pVertices[_49CE9E_sub0_y(pVertices, uNumVertices, pLimits[2].vWorldPosition.y)];
+        pOutLimits[1] = pVertices[_49CE9E_sub0_z(pVertices, uNumVertices, pLimits[1].vWorldPosition.z)];
+        pOutLimits[3] = pVertices[_49CE9E_sub0_z(pVertices, uNumVertices, pLimits[3].vWorldPosition.z)];
     }
 }
 
@@ -164,40 +128,28 @@ void stru10::CalcPolygonLimits(BLVFace *pFace, RenderVertexSoft *pOutVertices) {
     }
 
     RenderVertexSoft v1;  // [sp+30Ch] [bp-54h]@24
-    v1.vWorldPosition.x =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].x;
-    v1.vWorldPosition.y =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].y;
-    v1.vWorldPosition.z =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].z;
-    memcpy(&pOutVertices[0], &v1, sizeof(RenderVertexSoft));
+    v1.vWorldPosition.x = pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].x;
+    v1.vWorldPosition.y = pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].y;
+    v1.vWorldPosition.z = pIndoor->pVertices[pFace->pVertexIDs[x_min_idx]].z;
+    pOutVertices[0] = v1;
 
     RenderVertexSoft v2;  // [sp+30Ch] [bp-54h]@24
-    v2.vWorldPosition.x =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].x;
-    v2.vWorldPosition.y =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].y;
-    v2.vWorldPosition.z =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].z;
-    memcpy(&pOutVertices[1], &v2, sizeof(RenderVertexSoft));
+    v2.vWorldPosition.x = pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].x;
+    v2.vWorldPosition.y = pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].y;
+    v2.vWorldPosition.z = pIndoor->pVertices[pFace->pVertexIDs[y_min_idx]].z;
+    pOutVertices[1] = v2;
 
     RenderVertexSoft v3;  // [sp+30Ch] [bp-54h]@24
-    v3.vWorldPosition.x =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].x;
-    v3.vWorldPosition.y =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].y;
-    v3.vWorldPosition.z =
-        (float)pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].z;
-    memcpy(&pOutVertices[2], &v3, sizeof(RenderVertexSoft));
+    v3.vWorldPosition.x = pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].x;
+    v3.vWorldPosition.y = pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].y;
+    v3.vWorldPosition.z = pIndoor->pVertices[pFace->pVertexIDs[x_max_idx]].z;
+    pOutVertices[2] = v3;
 
     RenderVertexSoft v4;  // [sp+30Ch] [bp-54h]@24
-    v4.vWorldPosition.x =
-        (double)pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].x;
-    v4.vWorldPosition.y =
-        (double)pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].y;
-    v4.vWorldPosition.z =
-        (double)pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].z;
-    memcpy(&pOutVertices[3], &v4, sizeof(RenderVertexSoft));
+    v4.vWorldPosition.x = pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].x;
+    v4.vWorldPosition.y = pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].y;
+    v4.vWorldPosition.z = pIndoor->pVertices[pFace->pVertexIDs[y_max_idx]].z;
+    pOutVertices[3] = v4;
 }
 
 //----- (0049C9E3) --------------------------------------------------------
@@ -343,17 +295,15 @@ bool stru10::CalcFaceBounding(BLVFace *pFace, RenderVertexSoft *pFaceLimits,
     a1.z = pFace->pFacePlane.vNormal.z;
 
 
-    RenderVertexSoft v25;  // [sp+10h] [bp-90h]@20
-    memcpy(&v25, pOutBounding, sizeof(RenderVertexSoft));
-
+    RenderVertexSoft v25 = pOutBounding[0];  // [sp+10h] [bp-90h]@20
     float _dp = (v25.vWorldPosition.x - pCamera3D->vCameraPos.x) * a1.x +
                 (v25.vWorldPosition.y - pCamera3D->vCameraPos.y) * a1.y +
                 (v25.vWorldPosition.z - pCamera3D->vCameraPos.z) * a1.z;
     if (fabs(_dp) < 1e-6f) {
         logger->Info("Epsilon check");
-        memcpy(&v25, &pOutBounding[1], sizeof(RenderVertexSoft));
-        memcpy(&pOutBounding[1], &pOutBounding[3], sizeof(RenderVertexSoft));
-        memcpy(&pOutBounding[3], &v25, sizeof(RenderVertexSoft));
+        v25 = pOutBounding[1];
+        pOutBounding[1] = pOutBounding[3];
+        pOutBounding[3] = v25;
     }
 
 
@@ -412,10 +362,10 @@ bool stru10::CalcPortalShapePoly(BLVFace *pFace, RenderVertexSoft *pVertices,
 
         // make sure frustum planes will be on correct side
         if (pOutBounding[0].vWorldViewProjX > pOutBounding[3].vWorldViewProjX) {
-            memcpy(&pOutBounding[0], &temp[3], sizeof(RenderVertexSoft));
-            memcpy(&pOutBounding[2], &temp[1], sizeof(RenderVertexSoft));
-            memcpy(&pOutBounding[3], &temp[0], sizeof(RenderVertexSoft));
-            memcpy(&pOutBounding[1], &temp[2], sizeof(RenderVertexSoft));
+            pOutBounding[0] = temp[3];
+            pOutBounding[2] = temp[1];
+            pOutBounding[3] = temp[0];
+            pOutBounding[1] = temp[2];
         }
 
         // calculate the new frustum for this portal

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -2655,7 +2655,7 @@ void Actor::SummonMinion(int summonerId) {
     pActors[uNumActors].Reset();
     strcpy(actor->pActorName, v9->pName);
     actor->sCurrentHP = (short)v9->uHP;
-    memcpy(&actor->pMonsterInfo, v9, sizeof(actor->pMonsterInfo));
+    actor->pMonsterInfo = *v9;
     actor->word_000086_some_monster_id = summonMonsterBaseType;
     actor->uActorRadius = pMonsterList->pMonsters[v7].uMonsterRadius;
     actor->uActorHeight = pMonsterList->pMonsters[v7].uMonsterHeight;
@@ -3655,7 +3655,7 @@ void Actor::Arena_summon_actor(int monster_id, __int16 x, int y, int z) {
                pMonsterStats->pInfos[monster_id].pName);
         pActors[uNumActors].sCurrentHP =
             (short)pMonsterStats->pInfos[monster_id].uHP;
-        memcpy(&pActors[uNumActors].pMonsterInfo, &pMonsterStats->pInfos[monster_id], sizeof(MonsterInfo));
+        pActors[uNumActors].pMonsterInfo = pMonsterStats->pInfos[monster_id];
         pActors[uNumActors].word_000086_some_monster_id = monster_id;
         pActors[uNumActors].uActorRadius =
             pMonsterList->pMonsters[monster_id - 1].uMonsterRadius;
@@ -4092,7 +4092,7 @@ void Actor::LootActor() {
     }
     if (this->ActorHasItem()) {
         if (this->ActorHasItems[3].uItemID) {
-            memcpy(&Dst, &this->ActorHasItems[3], sizeof(Dst));
+            Dst = this->ActorHasItems[3];
             this->ActorHasItems[3].Reset();
 
             StatusBarItemFound(
@@ -4839,8 +4839,7 @@ bool SpawnActor(unsigned int uMonsterID) {
         memset(&actor, 0, sizeof(Actor));
         strcpy(actor.pActorName, pMonsterStats->pInfos[v1 + 1].pName);
         actor.sCurrentHP = (short)pMonsterStats->pInfos[v1 + 1].uHP;
-        memcpy(&actor.pMonsterInfo, &pMonsterStats->pInfos[v1 + 1],
-               sizeof(MonsterInfo));
+        actor.pMonsterInfo = pMonsterStats->pInfos[v1 + 1];
         actor.word_000086_some_monster_id = v1 + 1;
         actor.uActorRadius = pMonsterList->pMonsters[v1].uMonsterRadius;
         actor.uActorHeight = pMonsterList->pMonsters[v1].uMonsterHeight;
@@ -4862,7 +4861,7 @@ bool SpawnActor(unsigned int uMonsterID) {
             dword_5C6DF8 = 0;
             v6 = uNumActors++;
         }
-        memcpy(&pActors[v6], &actor, sizeof(Actor));
+        pActors[v6] = actor;
         pActors[v6].PrepareSprites(1);
         result = 1;
     }


### PR DESCRIPTION
Just making the code more c++ish here and there:
* Using std::array instead of C arrays.
* Using struct assignments instead of memcpy / field-by-field copying.