### PR TITLE
mostly fixes

### DIFF
--- a/1.diff
+++ b/1.diff
@@ -1,0 +1,874 @@
+diff --git a/Engine/Engine.h b/Engine/Engine.h
+index bf60c29..8f61af5 100644
+--- a/Engine/Engine.h
++++ b/Engine/Engine.h
+@@ -217,6 +217,12 @@ struct Engine {
+                 cfg->extended_draw_distance = extended_draw_distance;
+             });
+     }
++    inline void SetVerboseLogging(bool verbose_logging) {
++        MutateConfig(
++            [verbose_logging](std::shared_ptr<EngineConfig> &cfg) {
++                cfg->verbose_logging = verbose_logging;
++            });
++    }
+     inline void SetNoActors(bool no_actors) {
+         MutateConfig(
+             [no_actors](std::shared_ptr<EngineConfig> &cfg) {
+@@ -347,13 +353,6 @@ struct Engine {
+         });
+     }
+ 
+-    inline void ToggleDebugDrawDist() {
+-        MutateConfig(
+-            [](std::shared_ptr<EngineConfig> &cfg) {
+-            cfg->ToggleDebugDrawDist();
+-        });
+-    }
+-
+     inline void ToggleDebugSnow() {
+         MutateConfig(
+             [](std::shared_ptr<EngineConfig> &cfg) {
+@@ -403,6 +402,13 @@ struct Engine {
+             });
+     }
+ 
++    inline void ToggleVerboseLogging() {
++        MutateConfig(
++            [](std::shared_ptr<EngineConfig> &cfg) {
++                cfg->ToggleVerboseLogging();
++            });
++    }
++
+     inline void SetMusicLevel(int level) {
+         MutateConfig(
+             [level](std::shared_ptr<EngineConfig> &cfg) {
+diff --git a/Engine/EngineConfig.h b/Engine/EngineConfig.h
+index f6b8031..da9cdf4 100644
+--- a/Engine/EngineConfig.h
++++ b/Engine/EngineConfig.h
+@@ -76,7 +76,6 @@ class EngineConfig {
+     inline void ToggleDebugLightmap() { debug_lightmaps_decals = !debug_lightmaps_decals; }
+     inline void ToggleDebugTurboSpeed() { debug_turbo_speed = !debug_turbo_speed; }
+     inline void ToggleDebugNoActors() { no_actors = !no_actors; }
+-    inline void ToggleDebugDrawDist() { extended_draw_distance = !extended_draw_distance; }
+     inline void ToggleDebugSnow() { allow_snow = !allow_snow; }
+     inline void ToggleDebugNoDamage() { no_damage = !no_damage; }
+     inline void ToggleDebugPortalLines() { debug_portal_outlines = !debug_portal_outlines; }
+@@ -85,6 +84,7 @@ class EngineConfig {
+     inline void ToggleDebugSeasonsChange() { seasons_change = !seasons_change; }
+     inline void ToggleExtendedDrawDistance() { extended_draw_distance = !extended_draw_distance; }
+     inline void ToggleFullscreen() { fullscreen = !fullscreen; }
++    inline void ToggleVerboseLogging() { verbose_logging = !verbose_logging; }
+ 
+     // DEBUG_SETTINGS_*
+     int run_in_window = DEBUG_SETTINGS_RUN_IN_WIDOW;
+@@ -147,6 +147,7 @@ class EngineConfig {
+     bool debug_town_portal = false;
+     bool debug_infinite_gold = false;
+     bool debug_infinite_food = false;
++    bool verbose_logging = false;
+ 
+     bool always_run = true;
+     bool show_damage = true;
+diff --git a/Engine/Events.cpp b/Engine/Events.cpp
+index 758937d..5b047dc 100644
+--- a/Engine/Events.cpp
++++ b/Engine/Events.cpp
+@@ -321,12 +321,7 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
+     v133 = 0;
+     EvtTargetObj = targetObj;
+     dword_5B65C4_cancelEventProcessing = 0;
+-    if (uEventID == 114) {  // for test script
+-        // if (!lua->DoFile("out01.lua"))
+-        //    logger->Warning("Error opening out01.lua\n");
+-        // logger->Warning("being tested that well\n");
+-        return;
+-    }
++    logger->Warning("Processing EventID: %d", uEventID);
+     if (!uEventID) {
+         if (!game_ui_status_bar_event_string_time_left)
+             GameUI_SetStatusBar(LSTR_NOTHING_HERE);
+diff --git a/Engine/Graphics/Indoor.cpp b/Engine/Graphics/Indoor.cpp
+index 2dce0b1..1f1f598 100644
+--- a/Engine/Graphics/Indoor.cpp
++++ b/Engine/Graphics/Indoor.cpp
+@@ -1212,7 +1212,9 @@ int IndoorLocation::GetSector(int sX, int sY, int sZ) {
+ 
+     // No face found - outside of level
+     if (!NumFoundFaceStore) {
+-        logger->Warning("Sector fail");
++        if (engine->config->verbose_logging)
++            logger->Warning("Sector fail");
++
+         return 0;
+     }
+ 
+@@ -2301,7 +2303,9 @@ int BLV_GetFloorLevel(const Vec3_int_ &pos, unsigned int uSectorID, unsigned int
+ 
+     // no face found - probably wrong sector supplied
+     if (!FacesFound) {
+-        logger->Warning("Floorlvl fail");
++        if (engine->config->verbose_logging)
++            logger->Warning("Floorlvl fail");
++
+         return -30000;
+     }
+ 
+diff --git a/Engine/Graphics/Indoor.h b/Engine/Graphics/Indoor.h
+index 291a831..84401f4 100644
+--- a/Engine/Graphics/Indoor.h
++++ b/Engine/Graphics/Indoor.h
+@@ -457,7 +457,7 @@ struct BLVFace {  // 60h
+     struct Plane_float_ pFacePlane {};
+     struct Plane_int_ pFacePlane_old;
+     PlaneZCalc_int64_ zCalc;
+-    unsigned int uAttributes;
++    uint32_t uAttributes;
+     uint16_t *pVertexIDs = nullptr;
+     int16_t *pXInterceptDisplacements;
+     int16_t *pYInterceptDisplacements;
+diff --git a/Engine/Graphics/Viewport.cpp b/Engine/Graphics/Viewport.cpp
+index e04b65d..4de0488 100644
+--- a/Engine/Graphics/Viewport.cpp
++++ b/Engine/Graphics/Viewport.cpp
+@@ -235,6 +235,7 @@ void ItemInteraction(unsigned int item_id) {
+             pItemsTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName
+         );
+ 
++        // TODO: WTF? 184 / 185 qbits are associated with Tatalia's Mercenery Guild Harmondale raids. Are these about castle's tapestries ?
+         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER)
+             _449B7E_toggle_bit(pParty->_quest_bits, QBIT_SPLITTER_FOUND, 1);
+         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_SPELLBOOK_MIND_REMOVE_FEAR)
+diff --git a/Engine/Localization.cpp b/Engine/Localization.cpp
+index 44ec8a0..632dd9c 100644
+--- a/Engine/Localization.cpp
++++ b/Engine/Localization.cpp
+@@ -5,7 +5,8 @@
+ #include "Engine/LOD.h"
+ #include "Engine/Localization.h"
+ 
+-#define MAX_LOC_STRINGS 677
++#define MM7_LOC_STRINGS 677
++#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 3
+ extern std::vector<char *> Tokenize(char *input, const char separator);
+ 
+ Localization *localization = nullptr;
+@@ -43,12 +44,12 @@ bool Localization::Initialize() {
+         return false;
+     }
+ 
+-    this->localization_strings = new const char *[MAX_LOC_STRINGS];
++    this->localization_strings = new const char *[MAX_LOC_STRINGS]();
+ 
+     strtok(this->localization_raw, "\r");
+     strtok(NULL, "\r");
+ 
+-    for (int i = 0; i < MAX_LOC_STRINGS; ++i) {
++    for (int i = 0; i < MM7_LOC_STRINGS; ++i) {
+         char *test_string = strtok(NULL, "\r") + 1;
+         step = 0;
+         string_end = false;
+@@ -77,6 +78,14 @@ bool Localization::Initialize() {
+         } while (step <= 2 && !string_end);
+     }
+ 
++    // TODO: should be moved to localization files eventually
++    if (!this->localization_strings[LSTR_FMT_S_STOLE_D_ITEM])
++        this->localization_strings[LSTR_FMT_S_STOLE_D_ITEM] = "%s stole %s!";
++    if (!this->localization_strings[LSTR_FMT_RECOVERY_TIME_D])
++        this->localization_strings[LSTR_FMT_RECOVERY_TIME_D] = "Recovery time: %d";
++    if (!this->localization_strings[LSTR_FMT_S_U_OUT_OF_U])
++        this->localization_strings[LSTR_FMT_S_U_OUT_OF_U] = "%s: %lu out of %lu";
++
+     InitializeMm6ItemCategories();
+ 
+     InitializeMonthNames();
+diff --git a/Engine/Localization.h b/Engine/Localization.h
+index 143b1aa..f109e91 100644
+--- a/Engine/Localization.h
++++ b/Engine/Localization.h
+@@ -177,7 +177,7 @@
+ #define LSTR_ARCOMAGE_CARD_DISCARD          266  // "DISCARD A CARD"
+ #define LSTR_SHIELD                         279  // "Shield"
+ #define LSTR_OFFICIAL                       304  // "Official"
+-#define LSTR_FMT_S_STOLE_D_GOLD             320  // "%s stole %d gold!"
++#define LSTR_FMT_S_STOLE_D_GOLD             302  // "%s stole %d gold!"
+ #define LSTR_SET_BEACON                     375  // "Set Beacon"
+ #define LSTR_FMT_S_WAS_CAUGHT_STEALING      376  // "%s was caught stealing!"
+ #define LSTR_FMT_S_FAILED_TO_STEAL          377  // "%s failed to steal anything!"
+@@ -416,6 +416,10 @@
+                                                  // your plans.  Soon the world will bow to your every whim!
+                                                  // Still, you can't help but wonder what was beyond the Gate
+                                                  // the other side was trying so hard to build."
++// WoMM string IDs
++#define LSTR_FMT_S_STOLE_D_ITEM             677  // "%s stole %s!"
++#define LSTR_FMT_RECOVERY_TIME_D            678  // "Recovery time: %d"
++#define LSTR_FMT_S_U_OUT_OF_U               679  // "%s: %lu out of %lu"
+ 
+ class Localization {
+  public:
+diff --git a/Engine/Objects/Items.cpp b/Engine/Objects/Items.cpp
+index 7ae45f4..4b41692 100644
+--- a/Engine/Objects/Items.cpp
++++ b/Engine/Objects/Items.cpp
+@@ -144,6 +144,7 @@ void ItemGen::Reset() {
+     this->uHolderPlayer = 0;
+     this->uAttributes = 0;
+     this->uNumCharges = 0;
++    this->uMaxCharges = 0;
+     this->special_enchantment = ITEM_ENCHANTMENT_NULL;
+     this->m_enchantmentStrength = 0;
+     this->uEnchantmentType = 0;
+diff --git a/Engine/Objects/Items.h b/Engine/Objects/Items.h
+index c732808..a950b02 100644
+--- a/Engine/Objects/Items.h
++++ b/Engine/Objects/Items.h
+@@ -62,9 +62,9 @@ struct ItemGen {  // 0x24
+     uint8_t GetDamageRoll();
+     uint8_t GetDamageMod();
+     bool MerchandiseTest(int _2da_idx);
+-    int uItemID = 0;                // 0
+-    int uEnchantmentType = 0;       // 4
+-    int m_enchantmentStrength = 0;  // 8
++    int32_t uItemID = 0;               // 0
++    int32_t uEnchantmentType = 0;       // 4
++    int32_t m_enchantmentStrength = 0;  // 8
+     ITEM_ENCHANTMENT special_enchantment{};  // 0c
+                               // 25  +5 levels
+                               // 16  Drain Hit Points from target.
+@@ -84,12 +84,12 @@ struct ItemGen {  // 0x24
+                               // skill. 68  Adds 6-8 points of Cold damage and
+                               // +5 Armor Class. 71  Prevents drowning damage.
+                               // 72  Prevents falling damage.
+-    int uNumCharges = 0;              // 10
+-    unsigned int uAttributes = 0;     // 14
+-    uint8_t uBodyAnchor = 0;  // 18
+-    char uMaxCharges = 0;             // 19
+-    char uHolderPlayer = 0;           // 1A
+-    char field_1B = 0;                // 1B
++    int32_t uNumCharges = 0;           // 10
++    uint32_t uAttributes = 0;          // 14
++    uint8_t uBodyAnchor = 0;           // 18
++    uint8_t uMaxCharges = 0;           // 19
++    uint8_t uHolderPlayer = 0;         // 1A
++    char field_1B = 0;                 // 1B
+     GameTime uExpireTime;        // uint64_t uExpireTime; //1C
+ };
+ #pragma pack(pop)
+@@ -104,7 +104,7 @@ struct ItemDesc {  // 30h
+     char *pName;                  // 4 8
+     char *pUnidentifiedName;      // 8 c
+     char *pDescription;           // 0c 10
+-    unsigned int uValue;          // 10 14
++    uint32_t uValue;          // 10 14
+     uint16_t uSpriteID;   // 14 18
+     int16_t field_1A;             // 16
+     int16_t uEquipX;       // 18  1c
+diff --git a/Engine/Objects/Player.cpp b/Engine/Objects/Player.cpp
+index d2489f2..e0e7bba 100644
+--- a/Engine/Objects/Player.cpp
++++ b/Engine/Objects/Player.cpp
+@@ -1684,12 +1684,9 @@ int Player::StealFromActor(
+         actroPtr->SetRandomGoldIfTheresNoItem();  // add some gold
+ 
+     unsigned int stealskill = this->GetActualSkillLevel(PLAYER_SKILL_STEALING);
+-    unsigned int stealingMastery =
+-        this->GetActualSkillMastery(PLAYER_SKILL_STEALING);
+-    int currMaxItemValue = StealingRandomBonuses[rand() % 5] +
+-                           stealskill * StealingMasteryBonuses[stealingMastery];
+-    int fineIfFailed =
+-        actroPtr->pMonsterInfo.uLevel + 100 * (_steal_perm + reputation);
++    unsigned int stealingMastery = this->GetActualSkillMastery(PLAYER_SKILL_STEALING);
++    int currMaxItemValue = StealingRandomBonuses[rand() % 5] + stealskill * StealingMasteryBonuses[stealingMastery];
++    int fineIfFailed = actroPtr->pMonsterInfo.uLevel + 100 * (_steal_perm + reputation);
+ 
+     if (rand() % 100 < 5 || fineIfFailed > currMaxItemValue ||
+         actroPtr->ActorEnemy()) {  // busted
+@@ -1714,14 +1711,9 @@ int Player::StealFromActor(
+ 
+             unsigned int enchBonusSum = 0;  // how much to steal
+             for (int i = 0; i < stealskill; i++)
+-                enchBonusSum +=
+-                    rand() % StealingEnchantmentBonusForSkill[stealingMastery] +
+-                    1;  // add random stealing bonuses
++                enchBonusSum += rand() % StealingEnchantmentBonusForSkill[stealingMastery] + 1;  // add random stealing bonuses
+ 
+-            int* enchTypePtr;
+-            enchTypePtr = (int*)&actroPtr->ActorHasItems[3]
+-                              .special_enchantment;  // this is the amount of
+-                                                     // gold the actor has
++            int* enchTypePtr = (int*)&actroPtr->ActorHasItems[3].special_enchantment;  // actor has this amount of gold
+ 
+             if ((int)enchBonusSum >= *enchTypePtr) {  // steal all the gold
+                 enchBonusSum = *enchTypePtr;
+@@ -1752,22 +1744,17 @@ int Player::StealFromActor(
+             int randslot = rand() % 4;
+             unsigned int carriedItemId = actroPtr->uCarriedItemID;
+ 
+-            if (carriedItemId != 0 ||
+-                actroPtr->ActorHasItems[randslot].uItemID != 0 &&
+-                    actroPtr->ActorHasItems[randslot].GetItemEquipType() !=
+-                        EQUIP_GOLD) {  // check we have an item to steal
+-                if (carriedItemId != 0) {  // load item into tempitem
++            // check we have an item to steal
++            if (carriedItemId != ITEM_NULL || actroPtr->ActorHasItems[randslot].uItemID != 0 && actroPtr->ActorHasItems[randslot].GetItemEquipType() != EQUIP_GOLD) {
++                if (carriedItemId != ITEM_NULL) {  // load item into tempitem
+                     actroPtr->uCarriedItemID = 0;
+                     tempItem.uItemID = carriedItemId;
+-                    if (pItemsTable->pItems[carriedItemId].uEquipType ==
+-                        EQUIP_WAND)
+-                        tempItem.uNumCharges =
+-                            rand() % 6 +
+-                            pItemsTable->pItems[carriedItemId].uDamageMod + 1;
+-                    else if (pItemsTable->pItems[carriedItemId].uEquipType ==
+-                                 EQUIP_POTION &&
+-                             carriedItemId != ITEM_POTION_BOTTLE)
++                    if (pItemsTable->pItems[carriedItemId].uEquipType == EQUIP_WAND) {
++                        tempItem.uNumCharges = rand() % 6 + pItemsTable->pItems[carriedItemId].uDamageMod + 1;
++                        tempItem.uMaxCharges = tempItem.uNumCharges;
++                    } else if (pItemsTable->pItems[carriedItemId].uEquipType == EQUIP_POTION && carriedItemId != ITEM_POTION_BOTTLE) {
+                         tempItem.uEnchantmentType = 2 * rand() % 4 + 2;
++                    }
+                 } else {
+                     ItemGen* itemToSteal = &actroPtr->ActorHasItems[randslot];
+                     memcpy(&tempItem, itemToSteal, sizeof(tempItem));
+@@ -1775,24 +1762,13 @@ int Player::StealFromActor(
+                     carriedItemId = tempItem.uItemID;
+                 }
+ 
+-                if (carriedItemId !=
+-                    0) {  // looks odd in current context, but avoids accessing
+-                          // zeroth element of pItemsTable->pItems
+-
+-                    __debugbreak();  // no %s stole %s fmt string
+-                                     // the below would case a stack corruption
++                if (carriedItemId != ITEM_NULL) {
+                     GameUI_SetStatusBar(
+-                        LSTR_OFFICIAL,
++                        LSTR_FMT_S_STOLE_D_ITEM,
+                         this->pName,
+                         pItemsTable->pItems[carriedItemId].pUnidentifiedName
+                     );
+-
+-                    pParty->PickedItem_PlaceInInventory_or_Drop();  // drop or place picked item
+-
+-                    memcpy(
+-                        &pParty->pPickedItem, &tempItem,
+-                        sizeof(ItemGen));
+-                    mouse->SetCursorBitmapFromItemID(carriedItemId);
++                    pParty->SetHoldingItem(&tempItem);
+                     return STEAL_SUCCESS;
+                 }
+             }
+@@ -4680,17 +4656,12 @@ bool Player::CompareVariable(enum VariableType VarNum, int pValue) {
+     int actStat;                           // ebx@161
+     int baseStat;                          // eax@161
+ 
+-    if ((signed int)VarNum >= VAR_MapPersistentVariable_0 &&
+-        VarNum <= VAR_MapPersistentVariable_74)
+-        return (unsigned __int8)stru_5E4C90_MapPersistVars
+-                   .field_0[VarNum - VAR_MapPersistentVariable_0] >
+-               0;  // originally (unsigned __int8)byte_5E4C15[VarNum];
+-    if ((signed int)VarNum >= VAR_MapPersistentVariable_75 &&
+-        VarNum <= VAR_MapPersistentVariable_99)
+-        return (unsigned __int8)stru_5E4C90_MapPersistVars
+-                   ._decor_events[VarNum - VAR_MapPersistentVariable_75] >
+-               0;  // not really sure whether the number gets up to 99, but
+-                   // can't ignore the possibility
++    if ((signed int)VarNum >= VAR_MapPersistentVariable_0 && VarNum <= VAR_MapPersistentVariable_74)
++        return (unsigned __int8)stru_5E4C90_MapPersistVars.field_0[VarNum - VAR_MapPersistentVariable_0] >= pValue;  // originally (unsigned __int8)byte_5E4C15[VarNum];
++
++    // not really sure whether the number gets up to 99, but can't ignore the possibility
++    if ((signed int)VarNum >= VAR_MapPersistentVariable_75 && VarNum <= VAR_MapPersistentVariable_99)
++        return (unsigned __int8)stru_5E4C90_MapPersistVars._decor_events[VarNum - VAR_MapPersistentVariable_75] >= pValue;
+ 
+     switch (VarNum) {
+         case VAR_Sex:
+@@ -4720,8 +4691,7 @@ bool Player::CompareVariable(enum VariableType VarNum, int pValue) {
+         case VAR_Award:
+             return _449B57_test_bit(this->_achieved_awards_bits, pValue);
+         case VAR_Experience:
+-            return this->uExperience >=
+-                   pValue;  // TODO(_) change pValue to long long
++            return this->uExperience >= pValue;  // TODO(_) change pValue to long long
+         case VAR_QBits_QuestsDone:
+             return _449B57_test_bit(pParty->_quest_bits, pValue);
+         case VAR_PlayerItemInHands:
+@@ -5091,8 +5061,7 @@ void Player::SetVariable(enum VariableType var_type, signed int var_value) {
+ 
+     if (var_type >= VAR_History_0 && var_type <= VAR_History_28) {
+         if (!pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0]) {
+-            pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0] =
+-                pParty->GetPlayingTime();
++            pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0] = pParty->GetPlayingTime();
+             if (pStorylineText->StoreLine[var_type - VAR_History_0].pText) {
+                 bFlashHistoryBook = 1;
+                 PlayAwardSound();
+@@ -5101,27 +5070,18 @@ void Player::SetVariable(enum VariableType var_type, signed int var_value) {
+         return;
+     }
+ 
+-    if (var_type >= VAR_MapPersistentVariable_0 &&
+-        var_type <= VAR_MapPersistentVariable_99) {
+-        if (var_type >= VAR_MapPersistentVariable_0 &&
+-            var_type <= VAR_MapPersistentVariable_74)
+-            stru_5E4C90_MapPersistVars
+-                .field_0[var_type - VAR_MapPersistentVariable_0] =
+-                (char)var_value;
+-        if (var_type >= VAR_MapPersistentVariable_75 &&
+-            var_type <= VAR_MapPersistentVariable_99)
+-            stru_5E4C90_MapPersistVars
+-                ._decor_events[var_type - VAR_MapPersistentVariable_75] =
+-                (unsigned char)
+-                    var_value;  // not really sure whether the number gets up to
+-                                // 99, but can't ignore the possibility
++    if (var_type >= VAR_MapPersistentVariable_0 && var_type <= VAR_MapPersistentVariable_99) {
++        if (var_type >= VAR_MapPersistentVariable_0 && var_type <= VAR_MapPersistentVariable_74)
++            stru_5E4C90_MapPersistVars.field_0[var_type - VAR_MapPersistentVariable_0] = (char)var_value;
++
++        // not really sure whether the number gets up to 99, but can't ignore the possibility
++        if (var_type >= VAR_MapPersistentVariable_75 && var_type <= VAR_MapPersistentVariable_99)
++            stru_5E4C90_MapPersistVars._decor_events[var_type - VAR_MapPersistentVariable_75] = (unsigned char)var_value;
+         return;
+     }
+ 
+-    if (var_type >= VAR_UnknownTimeEvent0 &&
+-        var_type <= VAR_UnknownTimeEvent19) {
+-        pParty->PartyTimes._s_times[var_type - VAR_UnknownTimeEvent0] =
+-            pParty->GetPlayingTime();
++    if (var_type >= VAR_UnknownTimeEvent0 && var_type <= VAR_UnknownTimeEvent19) {
++        pParty->PartyTimes._s_times[var_type - VAR_UnknownTimeEvent0] = pParty->GetPlayingTime();
+         PlayAwardSound();
+         return;
+     }
+@@ -5203,7 +5163,7 @@ void Player::SetVariable(enum VariableType var_type, signed int var_value) {
+             PlayAwardSound_Anim();
+             return;
+         case VAR_QBits_QuestsDone:
+-            if (!_449B57_test_bit(pParty->_quest_bits, var_value) && pQuestTable[var_value - 1]) {
++            if (!_449B57_test_bit(pParty->_quest_bits, var_value) && pQuestTable[var_value]) {
+                 bFlashQuestBook = 1;
+                 spell_fx_renderer->SetPlayerBuffAnim(0x96u, GetPlayerIndex());
+                 PlayAwardSound();
+@@ -5685,53 +5645,36 @@ void Player::AddVariable(enum VariableType var_type, signed int val) {
+     ItemGen item;         // [sp+Ch] [bp-2Ch]@45
+ 
+     if (var_type >= VAR_Counter1 && var_type <= VAR_Counter10) {
+-        pParty->PartyTimes.CounterEventValues[var_type - VAR_Counter1] =
+-            pParty->GetPlayingTime();
++        pParty->PartyTimes.CounterEventValues[var_type - VAR_Counter1] = pParty->GetPlayingTime();
+         return;
+     }
+ 
+-    if (var_type >= VAR_UnknownTimeEvent0 &&
+-        var_type <= VAR_UnknownTimeEvent19) {
+-        pParty->PartyTimes._s_times[var_type - VAR_UnknownTimeEvent0] =
+-            pParty->GetPlayingTime();
++    if (var_type >= VAR_UnknownTimeEvent0 && var_type <= VAR_UnknownTimeEvent19) {
++        pParty->PartyTimes._s_times[var_type - VAR_UnknownTimeEvent0] = pParty->GetPlayingTime();
+         PlayAwardSound();
+         return;
+     }
+ 
+-    if (var_type >= VAR_MapPersistentVariable_0 &&
+-        var_type <= VAR_MapPersistentVariable_99) {
+-        if (var_type >= VAR_MapPersistentVariable_0 &&
+-            var_type <= VAR_MapPersistentVariable_74) {
+-            if (255 - val >
+-                stru_5E4C90_MapPersistVars
+-                    .field_0[var_type - VAR_MapPersistentVariable_0])
+-                stru_5E4C90_MapPersistVars
+-                    .field_0[var_type - VAR_MapPersistentVariable_0] += val;
++    if (var_type >= VAR_MapPersistentVariable_0 && var_type <= VAR_MapPersistentVariable_99) {
++        if (var_type >= VAR_MapPersistentVariable_0 && var_type <= VAR_MapPersistentVariable_74) {
++            if (255 - val > stru_5E4C90_MapPersistVars.field_0[var_type - VAR_MapPersistentVariable_0])
++                stru_5E4C90_MapPersistVars.field_0[var_type - VAR_MapPersistentVariable_0] += val;
+             else
+-                stru_5E4C90_MapPersistVars
+-                    .field_0[var_type - VAR_MapPersistentVariable_0] = 255;
++                stru_5E4C90_MapPersistVars.field_0[var_type - VAR_MapPersistentVariable_0] = 255;
+         }
+-        if ((signed int)var_type >= VAR_MapPersistentVariable_75 &&
+-            var_type <= VAR_MapPersistentVariable_99) {
+-            if (255 - val >
+-                stru_5E4C90_MapPersistVars
+-                    ._decor_events[var_type - VAR_MapPersistentVariable_75])
+-                stru_5E4C90_MapPersistVars
+-                    ._decor_events[var_type - VAR_MapPersistentVariable_75] +=
+-                    val;
++        if ((signed int)var_type >= VAR_MapPersistentVariable_75 && var_type <= VAR_MapPersistentVariable_99) {
++            if (255 - val > stru_5E4C90_MapPersistVars._decor_events[var_type - VAR_MapPersistentVariable_75])
++                stru_5E4C90_MapPersistVars._decor_events[var_type - VAR_MapPersistentVariable_75] += val;
+             else
+-                stru_5E4C90_MapPersistVars
+-                    ._decor_events[var_type - VAR_MapPersistentVariable_75] =
+-                    255;
++                stru_5E4C90_MapPersistVars._decor_events[var_type - VAR_MapPersistentVariable_75] = 255;
+         }
+         return;
+     }
+ 
+     if (var_type >= VAR_History_0 && var_type <= VAR_History_28) {
+         if (!pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0]) {
+-            pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0] =
+-                pParty->GetPlayingTime();
+-            if (pStorylineText->StoreLine[var_type - VAR_History_0].pText == 0) {
++            pParty->PartyTimes.HistoryEventTimes[var_type - VAR_History_0] = pParty->GetPlayingTime();
++            if (pStorylineText->StoreLine[var_type - VAR_History_0].pText) {
+                 bFlashHistoryBook = 1;
+                 PlayAwardSound();
+             }
+@@ -7378,8 +7321,8 @@ void Player::OnInventoryLeftClick() {
+                         (CastSpellInfo*)pGUIWindow_CastTargetedSpell->ptr_1C;
+                     pSpellInfo->uFlags &= 0x7F;
+                     pSpellInfo->uPlayerID_2 = uActiveCharacter - 1;
+-                    pSpellInfo->spell_target_pid = enchantedItemPos;  // - 1;
+-                    pSpellInfo->field_6 = (-1 - enchantedItemPos);    // check
++                    pSpellInfo->spell_target_pid = enchantedItemPos - 1;
++                    pSpellInfo->field_6 = this->GetItemMainInventoryIndex(invMatrixIndex);
+                     ptr_50C9A4_ItemToEnchant = &this->pInventoryItemList[enchantedItemPos - 1];
+                     _50C9A0_IsEnchantingInProgress = 0;
+ 
+@@ -7394,7 +7337,8 @@ void Player::OnInventoryLeftClick() {
+                 return;
+             }
+ 
+-            if (ptr_50C9A4_ItemToEnchant) return;
++            if (ptr_50C9A4_ItemToEnchant)
++                return;
+ 
+             pickedItemId = pParty->pPickedItem.uItemID;
+             invItemIndex = this->GetItemListAtInventoryIndex(invMatrixIndex);
+diff --git a/Engine/Objects/SpriteObject.cpp b/Engine/Objects/SpriteObject.cpp
+index f4607c6..c048e3c 100644
+--- a/Engine/Objects/SpriteObject.cpp
++++ b/Engine/Objects/SpriteObject.cpp
+@@ -498,7 +498,13 @@ void SpriteObject::UpdateObject_fn0_BLV(unsigned int uLayingItemID) {
+     int v40;                      // [sp+84h] [bp-Ch]@28
+ 
+ 
+-    if (pObject->uFlags & OBJECT_DESC_NO_GRAVITY) {  //не падающие объекты
++    if (pObject->uFlags & OBJECT_DESC_NO_GRAVITY) {
++        goto LABEL_25;
++    }
++
++    // flying objects / projectiles
++    if (floor_lvl <= pSpriteObject->vPosition.z - 3) {
++        pSpriteObject->vVelocity.z -= (short)pEventTimer->uTimeElapsed * GetGravityStrength();
+ LABEL_25:
+         collision_state.check_hi = false;
+         collision_state.radius_lo = pObject->uRadius;
+@@ -722,13 +728,6 @@ LABEL_25:
+         }
+         // end loop
+     }
+-    //для падающих объектов(для примера выброс вещи из инвентаря)
+-    // fallen objects, eg thrown out of inventory
+-    if (floor_lvl <= pSpriteObject->vPosition.z - 3) {
+-        pSpriteObject->vVelocity.z -=
+-            (short)pEventTimer->uTimeElapsed * GetGravityStrength();
+-        goto LABEL_25;
+-    }
+ 
+     if (!(pObject->uFlags & OBJECT_DESC_INTERACTABLE) ||
+         _46BFFA_update_spell_fx(uLayingItemID, 0)) {
+diff --git a/Engine/SaveLoad.cpp b/Engine/SaveLoad.cpp
+index 757f5cb..3468c73 100644
+--- a/Engine/SaveLoad.cpp
++++ b/Engine/SaveLoad.cpp
+@@ -239,7 +239,11 @@ void LoadGame(unsigned int uSlot) {
+         pParty->sRotationZ = engine->config->turn_speed * pParty->sRotationZ / engine->config->turn_speed;
+     }
+     MM7Initialization();
++
++    // TODO: disable flashing for all books until we save state to savegame file
+     bFlashQuestBook = false;
++    bFlashAutonotesBook = false;
++    bFlashHistoryBook = false;
+     viewparams->bRedrawGameUI = true;
+ }
+ 
+diff --git a/Engine/Spells/CastSpellInfo.cpp b/Engine/Spells/CastSpellInfo.cpp
+index 7341271..42ab06b 100644
+--- a/Engine/Spells/CastSpellInfo.cpp
++++ b/Engine/Spells/CastSpellInfo.cpp
+@@ -164,7 +164,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+                     0);  // target direciton
+             } else {
+                 target_direction.uYawAngle = pParty->sRotationZ;  // spray infront of party
+-                target_direction.uPitchAngle = -pParty->sRotationY;
++                target_direction.uPitchAngle = pParty->sRotationY;
+             }
+         }
+ 
+@@ -851,9 +851,10 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+                     default:
+                         assert(false);
+                 }
+-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+-                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2]
+-                             .pInventoryItemList[spell_targeted_at - 1];
++                if (!pPlayer->CanCastSpell(uRequiredMana))
++                    break;
++
++                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                 _item = &pItemsTable->pItems[v730c->uItemID];
+                 v730c->UpdateTempBonus(pParty->GetPlayingTime());
+                 if (v730c->uItemID < 64 ||
+@@ -1755,8 +1756,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+             case SPELL_WATER_RECHARGE_ITEM:
+             {
+                 if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+-                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[spell_targeted_at];
+-                if (v730c->GetItemEquipType() != 12 || v730c->uAttributes & 2) {
++                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
++                if (v730c->GetItemEquipType() != EQUIP_WAND || v730c->uAttributes & 2) {
+                     _50C9D0_AfterEnchClickEventId = 113;
+                     _50C9D4_AfterEnchClickEventSecondParam = 0;
+                     _50C9D8_AfterEnchClickEventTimeout = 1;
+@@ -1795,14 +1796,16 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+                 break;
+             }
+ 
+-            case SPELL_WATER_ENCHANT_ITEM: {  // Талисман
+-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
++            case SPELL_WATER_ENCHANT_ITEM: {
++                if (!pPlayer->CanCastSpell(uRequiredMana))
++                    break;
++
+                 uRequiredMana = 0;
+                 amount = 10 * spell_level;
+                 bool item_not_broken = true;
+                 int rnd = rand() % 100;
+                 pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
+-                spell_item_to_enchant = &pPlayer->pInventoryItemList[spell_targeted_at - 1];
++                spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
+                 ItemDesc *_v725 = &pItemsTable->pItems[spell_item_to_enchant->uItemID];
+                 char this_equip_type = _v725->uEquipType;
+ 
+@@ -2559,13 +2562,10 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+                     if (!pActors[monster_id].ActorHasItem())
+                         pActors[monster_id].SetRandomGoldIfTheresNoItem();
+                     int gold_num = 0;
+-                    if (pItemsTable
+-                            ->pItems
+-                                [pActors[monster_id].ActorHasItems[3].uItemID]
+-                            .uEquipType == EQUIP_GOLD)
+-                        gold_num = pActors[monster_id]
+-                                       .ActorHasItems[3]
+-                                       .special_enchantment;
++                    if (pActors[monster_id].ActorHasItems[3].uItemID != 0) {
++                        if (pItemsTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
++                            gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
++                    }
+                     ItemGen item;
+                     item.Reset();
+                     if (pActors[monster_id].uCarriedItemID) {
+@@ -3595,17 +3595,18 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
+ 
+             case SPELL_DARK_VAMPIRIC_WEAPON:
+             {
++                if (!pPlayer->CanCastSpell(uRequiredMana))
++                    break;
++
+                 amount = 16;
+                 if (skill_level == 4)
+                     spellduration = 0;
+                 else
+                     spellduration = 3600 * spell_level;
+-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+-                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2]
+-                                     .pInventoryItemList[spell_targeted_at];
++
++                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                 item->UpdateTempBonus(pParty->GetPlayingTime());
+-                if (item->uItemID >= 64 && item->uItemID <= 65  // blasters
+-                    || item->uAttributes & 2 ||
++                if (item->uItemID >= ITEM_BLASTER && item->uItemID <= ITEM_LASER_RIFLE || item->uAttributes & 2 ||
+                     item->special_enchantment != 0 ||
+                     item->uEnchantmentType != 0 ||
+                     pItemsTable->pItems[item->uItemID].uEquipType != EQUIP_SINGLE_HANDED &&
+diff --git a/GUI/GUIWindow.h b/GUI/GUIWindow.h
+index d59a6aa..615ea97 100644
+--- a/GUI/GUIWindow.h
++++ b/GUI/GUIWindow.h
+@@ -242,7 +242,7 @@ enum UIMessageType : uint32_t {
+ 
+     UIMSG_DebugSpecialItem = 971,
+     UIMSG_DebugGenItem = 972,
+-    UIMSG_DebugFarClip = 973,
++    UIMSG_DebugVerboseLogging = 973,
+     UIMSG_DebugSeasonsChange = 974,
+     UIMSG_DebugShowFPS = 975,
+     UIMSG_DebugPickedFace = 976,
+@@ -252,7 +252,7 @@ enum UIMessageType : uint32_t {
+     UIMSG_DebugNoDamage = 980,
+     UIMSG_DebugFullHeal = 981,
+     UIMSG_DebugSnow = 982,
+-    UIMSG_DebugDrawDist = 983,
++    UIMSG_DebugExtendedDrawDistance = 983,
+     UIMSG_DebugNoActors = 984,
+     UIMSG_DebugTurboSpeed = 985,
+     UIMSG_DebugLightmap = 986,
+diff --git a/GUI/UI/UICharacter.cpp b/GUI/UI/UICharacter.cpp
+index d47eb12..3b2b39d 100644
+--- a/GUI/UI/UICharacter.cpp
++++ b/GUI/UI/UICharacter.cpp
+@@ -3228,8 +3228,8 @@ void OnPaperdollLeftClick() {
+         if (!pitem) return;
+         // pPlayers[uActiveCharacter]->get
+ 
+-        // enchanting??
+-        if (_50C9A0_IsEnchantingInProgress) {  // наложить закл на экипировку
++        // enchant / recharge item
++        if (_50C9A0_IsEnchantingInProgress) {
+             /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
+              *0x7Fu;//CastSpellInfo
+              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
+@@ -3240,8 +3240,7 @@ void OnPaperdollLeftClick() {
+             pSpellInfo = (CastSpellInfo *)pGUIWindow_CastTargetedSpell->ptr_1C;
+             pSpellInfo->uFlags &= 0x7F;
+             pSpellInfo->uPlayerID_2 = uActiveCharacter - 1;
+-            pSpellInfo->spell_target_pid =
+-                pPlayers[uActiveCharacter]->pEquipment.pIndices[pos];
++            pSpellInfo->spell_target_pid = pPlayers[uActiveCharacter]->pEquipment.pIndices[pos];
+             pSpellInfo->field_6 = pEquipType;
+ 
+             ptr_50C9A4_ItemToEnchant = pitem;
+@@ -3254,8 +3253,7 @@ void OnPaperdollLeftClick() {
+         } else {
+             if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
+                 pParty->SetHoldingItem(pitem);
+-                pPlayers[uActiveCharacter]
+-                    ->pEquipment.pIndices[pitem->uBodyAnchor - 1] = 0;
++                pPlayers[uActiveCharacter]->pEquipment.pIndices[pitem->uBodyAnchor - 1] = 0;
+                 pitem->Reset();
+ 
+                 // pParty->SetHoldingItem(&pPlayers[uActiveCharacter]->pInventoryItemList[v34
+diff --git a/GUI/UI/UIGame.cpp b/GUI/UI/UIGame.cpp
+index 68573ea..c2227a8 100644
+--- a/GUI/UI/UIGame.cpp
++++ b/GUI/UI/UIGame.cpp
+@@ -2232,7 +2232,7 @@ GUIWindow_DebugMenu::GUIWindow_DebugMenu()
+     GUIButton *pBtn_DebugLightMap = CreateButton(13, 221, width, height, 1, 0, UIMSG_DebugLightmap, 0, GameKey::None, "DEBUG TOGGLE LIGHTMAP DECAL");
+     GUIButton *pBtn_DebugTurbo = CreateButton(127, 221, width, height, 1, 0, UIMSG_DebugTurboSpeed, 0, GameKey::None, "DEBUG TOGGLE TURBO SPEED");
+     GUIButton *pBtn_DebugNoActors = CreateButton(241, 221, width, height, 1, 0, UIMSG_DebugNoActors, 0, GameKey::None, "DEBUG TOGGLE ACTORS");
+-    GUIButton *pBtn_DebugDrawDist = CreateButton(354, 221, width, height, 1, 0, UIMSG_DebugDrawDist, 0, GameKey::None, "DEBUG TOGGLE EXTENDED DRAW DISTANCE");
++    GUIButton *pBtn_DebugExtendedDrawDistance = CreateButton(354, 221, width, height, 1, 0, UIMSG_DebugExtendedDrawDistance, 0, GameKey::None, "DEBUG TOGGLE EXTENDED DRAW DISTANCE");
+ 
+     GUIButton *pBtn_DebugSnow = CreateButton(13, 248, width, height, 1, 0, UIMSG_DebugSnow, 0, GameKey::None, "DEBUG TOGGLE SNOW");
+     GUIButton *pBtn_DebugPortalLines = CreateButton(127, 248, width, height, 1, 0, UIMSG_DebugPortalLines, 0, GameKey::None, "DEBUG TOGGLE PORTAL OUTLINES");
+@@ -2240,7 +2240,7 @@ GUIWindow_DebugMenu::GUIWindow_DebugMenu()
+     GUIButton *pBtn_DebugShowFPS = CreateButton(354, 248, width, height, 1, 0, UIMSG_DebugShowFPS, 0, GameKey::None, "DEBUG TOGGLE SHOW FPS");
+ 
+     GUIButton *pBtn_DebugSeasonsChange = CreateButton(13, 275, width, height, 1, 0, UIMSG_DebugSeasonsChange, 0, GameKey::None, "DEBUG TOGGLE SEASONS CHANGE");
+-    GUIButton *pBtn_DebugFarClipToggle = CreateButton(127, 275, width, height, 1, 0, UIMSG_DebugFarClip, 0, GameKey::None, "DEBUG TOGGLE FAR CLIP DISTANCE");
++    GUIButton *pBtn_DebugVerboseLogging = CreateButton(127, 275, width, height, 1, 0, UIMSG_DebugVerboseLogging, 0, GameKey::None, "DEBUG TOGGLE VERBOSE LOGGING");
+     GUIButton *pBtn_DebugGenItem = CreateButton(241, 275, width, height, 1, 0, UIMSG_DebugGenItem, 0, GameKey::None, "DEBUG GENERATE RANDOM ITEM");
+     GUIButton *pBtn_DebugSpecialItem = CreateButton(354, 275, width, height, 1, 0, UIMSG_DebugSpecialItem, 0, GameKey::None, "DEBUG GENERATE RANDOM SPECIAL ITEM");
+ 
+@@ -2286,7 +2286,7 @@ void GUIWindow_DebugMenu::Update() {
+     buttonbox(354, 248, "Show FPS", engine->config->show_fps);
+ 
+     buttonbox(13, 275, "Seasons", engine->config->seasons_change);
+-    buttonbox(127, 275, "Far Clip", engine->config->extended_draw_distance);
++    buttonbox(127, 275, "Verbose Log", engine->config->verbose_logging);
+     buttonbox(241, 275, "Gen Item", 2);
+     buttonbox(354, 275, "Special Item", 2);
+ 
+diff --git a/GUI/UI/UIPopup.cpp b/GUI/UI/UIPopup.cpp
+index ba1a684..835f917 100644
+--- a/GUI/UI/UIPopup.cpp
++++ b/GUI/UI/UIPopup.cpp
+@@ -397,10 +397,10 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
+                 pItemsTable
+                 ->pSpecialEnchantments[inspect_item->special_enchantment - 1]
+                 .pBonusStatement);
+-        } else if (inspect_item->uNumCharges) {
++        } else if (inspect_item->GetItemEquipType() == EQUIP_WAND) {
+             sprintf(
+-                out_text + 200, "%s: %lu", localization->GetString(LSTR_CHARGES),
+-                inspect_item->uNumCharges
++                out_text + 200, localization->GetString(LSTR_FMT_S_U_OUT_OF_U), localization->GetString(LSTR_CHARGES),
++                inspect_item->uNumCharges, inspect_item->uMaxCharges
+             );
+         }
+     }
+@@ -1024,12 +1024,14 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
+     }
+ 
+     // ps - test to track ai states
+-    auto txttest = StringPrintf("%d", pActors[uActorID].uAIState);
+-    pFontSmallnum->GetLineWidth(txttest);
+-    pWindow->DrawTitleText(
+-        pFontSmallnum, 0,
+-        pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, 0, txttest,
+-        3);
++    if (engine->config->verbose_logging) {
++        auto txttest = StringPrintf("AI State: %d", pActors[uActorID].uAIState);
++        pFontSmallnum->GetLineWidth(txttest);
++        pWindow->DrawTitleText(
++            pFontSmallnum, 0,
++            pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, 0, txttest,
++            3);
++    }
+ }
+ 
+ //----- (00417BB5) --------------------------------------------------------
+@@ -1270,11 +1272,9 @@ void CharacterUI_StatsTab_ShowHint() {
+         case 15:  // Attack Bonus
+             if (pAttackBonusAttributeDescription) {
+                 int meleerecov = pPlayers[uActiveCharacter]->GetAttackRecoveryTime(false);
+-                char recov[100];
+-                sprintf(recov, "\n\nRecovery time: %d", meleerecov);
+-                std::string test = std::string(pAttackBonusAttributeDescription) + std::string(recov);
+-                CharacterUI_DrawTooltip(localization->GetString(LSTR_ATTACK_BONUS),
+-                    /*pAttackBonusAttributeDescription*/test);
++                std::string description = StringPrintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), meleerecov);
++                description = StringPrintf("%s\n\n%s", pAttackBonusAttributeDescription, description.c_str());
++                CharacterUI_DrawTooltip(localization->GetString(LSTR_ATTACK_BONUS), description);
+             }
+             break;
+ 
+@@ -1289,11 +1289,9 @@ void CharacterUI_StatsTab_ShowHint() {
+         case 17:  // Missle Bonus
+             if (pMissleBonusAttributeDescription) {
+                 int missrecov = pPlayers[uActiveCharacter]->GetAttackRecoveryTime(true);
+-                char recovm[100];
+-                sprintf(recovm, "\n\nRecovery time: %d", missrecov);
+-                std::string test2 = std::string(pAttackBonusAttributeDescription) + std::string(recovm);
+-                CharacterUI_DrawTooltip(localization->GetString(LSTR_SHOOT_BONUS),
+-                    /*pMissleBonusAttributeDescription*/test2);
++                std::string description = StringPrintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), missrecov);
++                description = StringPrintf("%s\n\n%s", pAttackBonusAttributeDescription, description.c_str());
++                CharacterUI_DrawTooltip(localization->GetString(LSTR_SHOOT_BONUS), description);
+             }
+             break;
+ 
+diff --git a/src/Application/Game.cpp b/src/Application/Game.cpp
+index ebdee8a..88f6f0d 100644
+--- a/src/Application/Game.cpp
++++ b/src/Application/Game.cpp
+@@ -2590,8 +2590,8 @@ void Game::EventLoop() {
+                     engine->ToggleDebugNoActors();
+                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
+                     continue;
+-                case UIMSG_DebugDrawDist:
+-                    engine->ToggleDebugDrawDist();
++                case UIMSG_DebugExtendedDrawDistance:
++                    engine->ToggleExtendedDrawDistance();
+                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
+                     continue;
+                 case UIMSG_DebugSnow:
+@@ -2618,8 +2618,8 @@ void Game::EventLoop() {
+                     engine->ToggleDebugSeasonsChange();
+                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
+                     continue;
+-                case UIMSG_DebugFarClip:
+-                    engine->ToggleExtendedDrawDistance();
++                case UIMSG_DebugVerboseLogging:
++                    engine->ToggleVerboseLogging();
+                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
+                     continue;
+                 default:

--- a/Engine/Engine.h
+++ b/Engine/Engine.h
@@ -217,6 +217,12 @@ struct Engine {
                 cfg->extended_draw_distance = extended_draw_distance;
             });
     }
+    inline void SetVerboseLogging(bool verbose_logging) {
+        MutateConfig(
+            [verbose_logging](std::shared_ptr<EngineConfig> &cfg) {
+                cfg->verbose_logging = verbose_logging;
+            });
+    }
     inline void SetNoActors(bool no_actors) {
         MutateConfig(
             [no_actors](std::shared_ptr<EngineConfig> &cfg) {
@@ -347,13 +353,6 @@ struct Engine {
         });
     }
 
-    inline void ToggleDebugDrawDist() {
-        MutateConfig(
-            [](std::shared_ptr<EngineConfig> &cfg) {
-            cfg->ToggleDebugDrawDist();
-        });
-    }
-
     inline void ToggleDebugSnow() {
         MutateConfig(
             [](std::shared_ptr<EngineConfig> &cfg) {
@@ -400,6 +399,13 @@ struct Engine {
         MutateConfig(
             [](std::shared_ptr<EngineConfig> &cfg) {
                 cfg->ToggleExtendedDrawDistance();
+            });
+    }
+
+    inline void ToggleVerboseLogging() {
+        MutateConfig(
+            [](std::shared_ptr<EngineConfig> &cfg) {
+                cfg->ToggleVerboseLogging();
             });
     }
 

--- a/Engine/EngineConfig.h
+++ b/Engine/EngineConfig.h
@@ -76,7 +76,6 @@ class EngineConfig {
     inline void ToggleDebugLightmap() { debug_lightmaps_decals = !debug_lightmaps_decals; }
     inline void ToggleDebugTurboSpeed() { debug_turbo_speed = !debug_turbo_speed; }
     inline void ToggleDebugNoActors() { no_actors = !no_actors; }
-    inline void ToggleDebugDrawDist() { extended_draw_distance = !extended_draw_distance; }
     inline void ToggleDebugSnow() { allow_snow = !allow_snow; }
     inline void ToggleDebugNoDamage() { no_damage = !no_damage; }
     inline void ToggleDebugPortalLines() { debug_portal_outlines = !debug_portal_outlines; }
@@ -85,6 +84,7 @@ class EngineConfig {
     inline void ToggleDebugSeasonsChange() { seasons_change = !seasons_change; }
     inline void ToggleExtendedDrawDistance() { extended_draw_distance = !extended_draw_distance; }
     inline void ToggleFullscreen() { fullscreen = !fullscreen; }
+    inline void ToggleVerboseLogging() { verbose_logging = !verbose_logging; }
 
     // DEBUG_SETTINGS_*
     int run_in_window = DEBUG_SETTINGS_RUN_IN_WIDOW;
@@ -147,6 +147,7 @@ class EngineConfig {
     bool debug_town_portal = false;
     bool debug_infinite_gold = false;
     bool debug_infinite_food = false;
+    bool verbose_logging = false;
 
     bool always_run = true;
     bool show_damage = true;

--- a/Engine/Events.cpp
+++ b/Engine/Events.cpp
@@ -321,12 +321,9 @@ void EventProcessor(int uEventID, int targetObj, int canShowMessages,
     v133 = 0;
     EvtTargetObj = targetObj;
     dword_5B65C4_cancelEventProcessing = 0;
-    if (uEventID == 114) {  // for test script
-        // if (!lua->DoFile("out01.lua"))
-        //    logger->Warning("Error opening out01.lua\n");
-        // logger->Warning("being tested that well\n");
-        return;
-    }
+    if (engine->config->verbose_logging)
+        logger->Warning("Processing EventID: %d", uEventID);
+
     if (!uEventID) {
         if (!game_ui_status_bar_event_string_time_left)
             GameUI_SetStatusBar(LSTR_NOTHING_HERE);

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1212,7 +1212,9 @@ int IndoorLocation::GetSector(int sX, int sY, int sZ) {
 
     // No face found - outside of level
     if (!NumFoundFaceStore) {
-        logger->Warning("Sector fail");
+        if (engine->config->verbose_logging)
+            logger->Warning("Sector fail");
+
         return 0;
     }
 
@@ -2301,7 +2303,9 @@ int BLV_GetFloorLevel(const Vec3_int_ &pos, unsigned int uSectorID, unsigned int
 
     // no face found - probably wrong sector supplied
     if (!FacesFound) {
-        logger->Warning("Floorlvl fail");
+        if (engine->config->verbose_logging)
+            logger->Warning("Floorlvl fail");
+
         return -30000;
     }
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -457,7 +457,7 @@ struct BLVFace {  // 60h
     struct Plane_float_ pFacePlane {};
     struct Plane_int_ pFacePlane_old;
     PlaneZCalc_int64_ zCalc;
-    unsigned int uAttributes;
+    uint32_t uAttributes;
     uint16_t *pVertexIDs = nullptr;
     int16_t *pXInterceptDisplacements;
     int16_t *pYInterceptDisplacements;

--- a/Engine/Graphics/Viewport.cpp
+++ b/Engine/Graphics/Viewport.cpp
@@ -235,6 +235,7 @@ void ItemInteraction(unsigned int item_id) {
             pItemsTable->pItems[pSpriteObjects[item_id].containing_item.uItemID].pUnidentifiedName
         );
 
+        // TODO: WTF? 184 / 185 qbits are associated with Tatalia's Mercenery Guild Harmondale raids. Are these about castle's tapestries ?
         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_ARTIFACT_SPLITTER)
             _449B7E_toggle_bit(pParty->_quest_bits, QBIT_SPLITTER_FOUND, 1);
         if (pSpriteObjects[item_id].containing_item.uItemID == ITEM_SPELLBOOK_MIND_REMOVE_FEAR)

--- a/Engine/Localization.cpp
+++ b/Engine/Localization.cpp
@@ -5,7 +5,8 @@
 #include "Engine/LOD.h"
 #include "Engine/Localization.h"
 
-#define MAX_LOC_STRINGS 677
+#define MM7_LOC_STRINGS 677
+#define MAX_LOC_STRINGS MM7_LOC_STRINGS + 3
 extern std::vector<char *> Tokenize(char *input, const char separator);
 
 Localization *localization = nullptr;
@@ -43,12 +44,12 @@ bool Localization::Initialize() {
         return false;
     }
 
-    this->localization_strings = new const char *[MAX_LOC_STRINGS];
+    this->localization_strings = new const char *[MAX_LOC_STRINGS]();
 
     strtok(this->localization_raw, "\r");
     strtok(NULL, "\r");
 
-    for (int i = 0; i < MAX_LOC_STRINGS; ++i) {
+    for (int i = 0; i < MM7_LOC_STRINGS; ++i) {
         char *test_string = strtok(NULL, "\r") + 1;
         step = 0;
         string_end = false;
@@ -76,6 +77,14 @@ bool Localization::Initialize() {
             test_string = tmp_pos + 1;
         } while (step <= 2 && !string_end);
     }
+
+    // TODO: should be moved to localization files eventually
+    if (!this->localization_strings[LSTR_FMT_S_STOLE_D_ITEM])
+        this->localization_strings[LSTR_FMT_S_STOLE_D_ITEM] = "%s stole %s!";
+    if (!this->localization_strings[LSTR_FMT_RECOVERY_TIME_D])
+        this->localization_strings[LSTR_FMT_RECOVERY_TIME_D] = "Recovery time: %d";
+    if (!this->localization_strings[LSTR_FMT_S_U_OUT_OF_U])
+        this->localization_strings[LSTR_FMT_S_U_OUT_OF_U] = "%s: %lu out of %lu";
 
     InitializeMm6ItemCategories();
 

--- a/Engine/Localization.h
+++ b/Engine/Localization.h
@@ -177,7 +177,7 @@
 #define LSTR_ARCOMAGE_CARD_DISCARD          266  // "DISCARD A CARD"
 #define LSTR_SHIELD                         279  // "Shield"
 #define LSTR_OFFICIAL                       304  // "Official"
-#define LSTR_FMT_S_STOLE_D_GOLD             320  // "%s stole %d gold!"
+#define LSTR_FMT_S_STOLE_D_GOLD             302  // "%s stole %d gold!"
 #define LSTR_SET_BEACON                     375  // "Set Beacon"
 #define LSTR_FMT_S_WAS_CAUGHT_STEALING      376  // "%s was caught stealing!"
 #define LSTR_FMT_S_FAILED_TO_STEAL          377  // "%s failed to steal anything!"
@@ -416,6 +416,10 @@
                                                  // your plans.  Soon the world will bow to your every whim!
                                                  // Still, you can't help but wonder what was beyond the Gate
                                                  // the other side was trying so hard to build."
+// WoMM string IDs
+#define LSTR_FMT_S_STOLE_D_ITEM             677  // "%s stole %s!"
+#define LSTR_FMT_RECOVERY_TIME_D            678  // "Recovery time: %d"
+#define LSTR_FMT_S_U_OUT_OF_U               679  // "%s: %lu out of %lu"
 
 class Localization {
  public:

--- a/Engine/Objects/Items.cpp
+++ b/Engine/Objects/Items.cpp
@@ -144,6 +144,7 @@ void ItemGen::Reset() {
     this->uHolderPlayer = 0;
     this->uAttributes = 0;
     this->uNumCharges = 0;
+    this->uMaxCharges = 0;
     this->special_enchantment = ITEM_ENCHANTMENT_NULL;
     this->m_enchantmentStrength = 0;
     this->uEnchantmentType = 0;

--- a/Engine/Objects/Items.h
+++ b/Engine/Objects/Items.h
@@ -62,9 +62,9 @@ struct ItemGen {  // 0x24
     uint8_t GetDamageRoll();
     uint8_t GetDamageMod();
     bool MerchandiseTest(int _2da_idx);
-    int uItemID = 0;                // 0
-    int uEnchantmentType = 0;       // 4
-    int m_enchantmentStrength = 0;  // 8
+    int32_t uItemID = 0;               // 0
+    int32_t uEnchantmentType = 0;       // 4
+    int32_t m_enchantmentStrength = 0;  // 8
     ITEM_ENCHANTMENT special_enchantment{};  // 0c
                               // 25  +5 levels
                               // 16  Drain Hit Points from target.
@@ -84,12 +84,12 @@ struct ItemGen {  // 0x24
                               // skill. 68  Adds 6-8 points of Cold damage and
                               // +5 Armor Class. 71  Prevents drowning damage.
                               // 72  Prevents falling damage.
-    int uNumCharges = 0;              // 10
-    unsigned int uAttributes = 0;     // 14
-    uint8_t uBodyAnchor = 0;  // 18
-    char uMaxCharges = 0;             // 19
-    char uHolderPlayer = 0;           // 1A
-    char field_1B = 0;                // 1B
+    int32_t uNumCharges = 0;           // 10
+    uint32_t uAttributes = 0;          // 14
+    uint8_t uBodyAnchor = 0;           // 18
+    uint8_t uMaxCharges = 0;           // 19
+    uint8_t uHolderPlayer = 0;         // 1A
+    char field_1B = 0;                 // 1B
     GameTime uExpireTime;        // uint64_t uExpireTime; //1C
 };
 #pragma pack(pop)
@@ -104,7 +104,7 @@ struct ItemDesc {  // 30h
     char *pName;                  // 4 8
     char *pUnidentifiedName;      // 8 c
     char *pDescription;           // 0c 10
-    unsigned int uValue;          // 10 14
+    uint32_t uValue;          // 10 14
     uint16_t uSpriteID;   // 14 18
     int16_t field_1A;             // 16
     int16_t uEquipX;       // 18  1c

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -498,7 +498,13 @@ void SpriteObject::UpdateObject_fn0_BLV(unsigned int uLayingItemID) {
     int v40;                      // [sp+84h] [bp-Ch]@28
 
 
-    if (pObject->uFlags & OBJECT_DESC_NO_GRAVITY) {  //не падающие объекты
+    if (pObject->uFlags & OBJECT_DESC_NO_GRAVITY) {
+        goto LABEL_25;
+    }
+
+    // flying objects / projectiles
+    if (floor_lvl <= pSpriteObject->vPosition.z - 3) {
+        pSpriteObject->vVelocity.z -= (short)pEventTimer->uTimeElapsed * GetGravityStrength();
 LABEL_25:
         collision_state.check_hi = false;
         collision_state.radius_lo = pObject->uRadius;
@@ -721,13 +727,6 @@ LABEL_25:
             pSpriteObject->vVelocity.z = fixpoint_mul(58500, pSpriteObject->vVelocity.z);
         }
         // end loop
-    }
-    //для падающих объектов(для примера выброс вещи из инвентаря)
-    // fallen objects, eg thrown out of inventory
-    if (floor_lvl <= pSpriteObject->vPosition.z - 3) {
-        pSpriteObject->vVelocity.z -=
-            (short)pEventTimer->uTimeElapsed * GetGravityStrength();
-        goto LABEL_25;
     }
 
     if (!(pObject->uFlags & OBJECT_DESC_INTERACTABLE) ||

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -239,7 +239,11 @@ void LoadGame(unsigned int uSlot) {
         pParty->sRotationZ = engine->config->turn_speed * pParty->sRotationZ / engine->config->turn_speed;
     }
     MM7Initialization();
+
+    // TODO: disable flashing for all books until we save state to savegame file
     bFlashQuestBook = false;
+    bFlashAutonotesBook = false;
+    bFlashHistoryBook = false;
     viewparams->bRedrawGameUI = true;
 }
 

--- a/Engine/Spells/CastSpellInfo.cpp
+++ b/Engine/Spells/CastSpellInfo.cpp
@@ -164,7 +164,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     0);  // target direciton
             } else {
                 target_direction.uYawAngle = pParty->sRotationZ;  // spray infront of party
-                target_direction.uPitchAngle = -pParty->sRotationY;
+                target_direction.uPitchAngle = pParty->sRotationY;
             }
         }
 
@@ -362,7 +362,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     default:
                         assert(false);
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
 
                 pParty->pPartyBuffs[PARTY_BUFF_TORCHLIGHT].Apply(
                     GameTime(pParty->GetPlayingTime() +
@@ -405,7 +406,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     pCastSpell->uSpellID = 0;
                     continue;
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 pSpellSprite.containing_item.Reset();
                 pSpellSprite.spell_id = pCastSpell->uSpellID;
                 pSpellSprite.spell_level = spell_level;
@@ -440,7 +442,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
             case SPELL_AIR_IMPLOSION:  //Точный взрыв
             {
                 monster_id = PID_ID(spell_targeted_at);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 if (!spell_targeted_at) {
                     GameUI_SetStatusBar(LSTR_SPELL_FAILED);
                     pAudioPlayer->PlaySound(SOUND_spellfail0201, 0, 0, -1, 0, 0);
@@ -455,24 +458,20 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     pSpellSprite.spell_id = pCastSpell->uSpellID;
                     pSpellSprite.spell_level = spell_level;
                     pSpellSprite.spell_skill = skill_level;
-                    pSpellSprite.uObjectDescID =
-                        pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                    pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                     pSpellSprite.uAttributes = 0;
                     pSpellSprite.uSectorID = 0;
                     pSpellSprite.uSpriteFrameID = 0;
                     pSpellSprite.field_60_distance_related_prolly_lod = 0;
                     pSpellSprite.uFacing = 0;
-                    pSpellSprite.spell_caster_pid =
-                        PID(OBJECT_Player, pCastSpell->uPlayerID);
+                    pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                     pSpellSprite.uSoundID = (short)pCastSpell->sound_id;
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.spell_target_pid =
                         PID(OBJECT_Actor, monster_id);
-                    Actor::DamageMonsterFromParty(
-                        PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                        monster_id, &v697);
+                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &v697);
                 }
                 spell_sound_flag = true;
                 break;
@@ -481,12 +480,10 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
             case SPELL_EARTH_MASS_DISTORTION:  //Изменение веса
             {
                 monster_id = PID_ID(spell_targeted_at);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 if (pActors[monster_id].DoesDmgTypeDoDamage((DAMAGE_TYPE)3)) {
-                    pActors[monster_id]
-                        .pActorBuffs[ACTOR_BUFF_MASS_DISTORTION]
-                        .Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), 0, 0, 0,
-                               0);
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_MASS_DISTORTION].Apply(GameTime(pMiscTimer->uTotalGameTimeElapsed + 128), 0, 0, 0, 0);
                     v704.x = 0;
                     v704.y = 0;
                     v704.z = 0;
@@ -494,24 +491,19 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     pSpellSprite.spell_id = pCastSpell->uSpellID;
                     pSpellSprite.spell_level = spell_level;
                     pSpellSprite.spell_skill = skill_level;
-                    pSpellSprite.uObjectDescID =
-                        pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                    pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                     pSpellSprite.uAttributes = 0;
                     pSpellSprite.uSectorID = 0;
                     pSpellSprite.uSpriteFrameID = 0;
                     pSpellSprite.field_60_distance_related_prolly_lod = 0;
                     pSpellSprite.uFacing = 0;
-                    pSpellSprite.spell_caster_pid =
-                        PID(OBJECT_Player, pCastSpell->uPlayerID);
+                    pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                     pSpellSprite.uSoundID = (short)pCastSpell->sound_id;
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z;
-                    pSpellSprite.spell_target_pid =
-                        PID(OBJECT_Actor, monster_id);
-                    Actor::DamageMonsterFromParty(
-                        PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                        monster_id, &v704);
+                    pSpellSprite.spell_target_pid = PID(OBJECT_Actor, monster_id);
+                    Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &v704);
                 }
                 spell_sound_flag = true;
                 break;
@@ -564,27 +556,27 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 break;
             }
 
-            case SPELL_FIRE_FIRE_BOLT:      //Удар огня
-            case SPELL_FIRE_FIREBALL:       //Огненный шар
-            case SPELL_FIRE_INCINERATE:     //Испепеление
-            case SPELL_AIR_LIGHNING_BOLT:   //Удар молнии
-            case SPELL_WATER_ICE_BOLT:      //Льдяная молния
-            case SPELL_WATER_ICE_BLAST:     //Льдяной взрыв
-            case SPELL_EARTH_STUN:          //Оглушить
-            case SPELL_EARTH_DEADLY_SWARM:  //Рой смерти
-            case SPELL_MIND_MIND_BLAST:     //Удар мысли
-            case SPELL_MIND_PSYCHIC_SHOCK:  //Психический шок
-            case SPELL_BODY_HARM:           //Вред
-            case SPELL_LIGHT_LIGHT_BOLT:    //Луч света
-            case SPELL_DARK_DRAGON_BREATH:  //Дыхание дракона
+            case SPELL_FIRE_FIRE_BOLT:
+            case SPELL_FIRE_FIREBALL:
+            case SPELL_FIRE_INCINERATE:
+            case SPELL_AIR_LIGHNING_BOLT:
+            case SPELL_WATER_ICE_BOLT:
+            case SPELL_WATER_ICE_BLAST:
+            case SPELL_EARTH_STUN:
+            case SPELL_EARTH_DEADLY_SWARM:
+            case SPELL_MIND_MIND_BLAST:
+            case SPELL_MIND_PSYCHIC_SHOCK:
+            case SPELL_BODY_HARM:
+            case SPELL_LIGHT_LIGHT_BOLT:
+            case SPELL_DARK_DRAGON_BREATH:
             {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 pSpellSprite.containing_item.Reset();
                 pSpellSprite.spell_id = pCastSpell->uSpellID;
                 pSpellSprite.spell_level = spell_level;
                 pSpellSprite.spell_skill = skill_level;
-                pSpellSprite.uObjectDescID =
-                    pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3_int_(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uAttributes = 0;
                 if (uCurrentlyLoadedLevelType == LEVEL_Indoor)
@@ -599,54 +591,45 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     target_direction.uDistance;
                 pSpellSprite.uFacing = target_direction.uYawAngle;
                 pSpellSprite.uSoundID = pCastSpell->sound_id;
-                if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes |= 4;
-                }
                 if (pCastSpell->uSpellID == SPELL_AIR_LIGHNING_BOLT)
                     pSpellSprite.uAttributes |= 0x40;
-                v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle,
-                    target_direction.uPitchAngle, v659,
-                    pCastSpell->uPlayerID + 1) != -1 &&
-                    pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
+                if (pParty->bTurnBasedModeOn) {
+                    pSpellSprite.uAttributes |= 4;
+                    v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, v659, pCastSpell->uPlayerID + 1) != -1) {
+                        ++pTurnEngine->pending_actions;
+                    }
                 }
                 spell_sound_flag = true;
                 break;
             }
 
-            case SPELL_WATER_ACID_BURST:  //Всплеск кислоты
-            case SPELL_EARTH_BLADES:      //Лезвия
-            case SPELL_BODY_FLYING_FIST:  //Летающий кулак
-            case SPELL_DARK_TOXIC_CLOUD:  //Облако-токсин
+            case SPELL_WATER_ACID_BURST:
+            case SPELL_EARTH_BLADES:
+            case SPELL_BODY_FLYING_FIST:
+            case SPELL_DARK_TOXIC_CLOUD:
             {
                 if (!pPlayer->CanCastSpell(uRequiredMana)) break;
                 pSpellSprite.containing_item.Reset();
                 pSpellSprite.spell_id = pCastSpell->uSpellID;
                 pSpellSprite.spell_level = spell_level;
                 pSpellSprite.spell_skill = skill_level;
-                pSpellSprite.uObjectDescID =
-                    pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                 pSpellSprite.uAttributes = 0;
                 pSpellSprite.vPosition = pParty->vPosition + Vec3_int_(0, 0, pParty->uPartyHeight / 2);
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.uSpriteFrameID = 0;
-                pSpellSprite.spell_caster_pid =
-                    PID(OBJECT_Player, pCastSpell->uPlayerID);
+                pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod =
-                    target_direction.uDistance;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                 pSpellSprite.uFacing = target_direction.uYawAngle;
                 pSpellSprite.uSoundID = pCastSpell->sound_id;
                 if (pParty->bTurnBasedModeOn) {
                     pSpellSprite.uAttributes |= 4;
-                }
-                v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle,
-                    target_direction.uPitchAngle, v659,
-                    pCastSpell->uPlayerID + 1) != -1 &&
-                    pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
+                    v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, v659, pCastSpell->uPlayerID + 1) != -1) {
+                        ++pTurnEngine->pending_actions;
+                    }
                 }
                 spell_sound_flag = true;
                 break;
@@ -678,31 +661,24 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     pSpellSprite.uSoundID = pCastSpell->sound_id;
                     if (pParty->bTurnBasedModeOn) {
                         pSpellSprite.uAttributes |= 4;
-                    }
-                    v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID]
-                               .uSpeed;
-                    if (pSpellSprite.Create(target_direction.uYawAngle,
-                                            target_direction.uPitchAngle, v659,
-                                            pCastSpell->uPlayerID + 1) != -1 &&
-                        pParty->bTurnBasedModeOn) {
-                        ++pTurnEngine->pending_actions;
+                        v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                        if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, v659, pCastSpell->uPlayerID + 1) != -1) {
+                            ++pTurnEngine->pending_actions;
+                        }
                     }
                     spell_sound_flag = true;
                 }
                 break;
             }
 
-            case SPELL_LIGHT_PARALYZE:  //Паралич
+            case SPELL_LIGHT_PARALYZE:
             {
                 if (!pPlayer->CanCastSpell(uRequiredMana)) break;
                 monster_id = PID_ID(spell_targeted_at);
                 if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
                     pActors[monster_id].DoesDmgTypeDoDamage((DAMAGE_TYPE)9)) {
                     Actor::AI_Stand(PID_ID(spell_targeted_at), 4, 0x80, 0);
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(
-                        GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(3 * 60 * spell_level)),
-                        skill_level, 0, 0, 0);
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_PARALYZED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3 * 60 * spell_level)), skill_level, 0, 0, 0);
                     pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
                     pActors[monster_id].vVelocity.x = 0;
                     pActors[monster_id].vVelocity.y = 0;
@@ -712,7 +688,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 break;
             }
 
-            case SPELL_EARTH_SLOW:  //Замедление
+            case SPELL_EARTH_SLOW:
             {
                 switch (skill_level) {
                     case 1:
@@ -734,15 +710,12 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     default:
                         assert(false);
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 // v721 = 836 * PID_ID(spell_targeted_at);
                 monster_id = PID_ID(spell_targeted_at);
-                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor &&
-                    pActors[monster_id].DoesDmgTypeDoDamage((DAMAGE_TYPE)3)) {
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(
-                        GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(spellduration)),
-                        skill_level, amount, 0, 0);
+                if (PID_TYPE(spell_targeted_at) == OBJECT_Actor && pActors[monster_id].DoesDmgTypeDoDamage((DAMAGE_TYPE)3)) {
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_SLOWED].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), skill_level, amount, 0, 0);
                     pActors[monster_id].uAttributes |= ACTOR_AGGRESSOR;
                     spell_fx_renderer->_4A7E89_sparkles_on_actor_after_it_casts_buff(&pActors[monster_id], 0);
                 }
@@ -750,10 +723,11 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 break;
             }
 
-            case SPELL_MIND_CHARM:  // Очарование
+            case SPELL_MIND_CHARM:
             {
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 monster_id = PID_ID(spell_targeted_at);
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
                 if (pActors[monster_id].DoesDmgTypeDoDamage((DAMAGE_TYPE)7)) {
                     uint power = 300 * spell_level;
                     if (skill_level == 2)
@@ -762,30 +736,22 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         power = 29030400;
 
                     pActors[monster_id].pActorBuffs[ACTOR_BUFF_BERSERK].Reset();
-                    pActors[monster_id]
-                        .pActorBuffs[ACTOR_BUFF_ENSLAVED]
-                        .Reset();
-                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(
-                        GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(power << 7)),
-                        skill_level, 0, 0, 0);
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_ENSLAVED].Reset();
+                    pActors[monster_id].pActorBuffs[ACTOR_BUFF_CHARM].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(power << 7)), skill_level, 0, 0, 0);
                     pSpellSprite.containing_item.Reset();
                     pSpellSprite.spell_id = pCastSpell->uSpellID;
                     pSpellSprite.spell_level = spell_level;
                     pSpellSprite.spell_skill = skill_level;
-                    pSpellSprite.uObjectDescID =
-                        pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                    pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                     pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
                     pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
                     pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z + pActors[monster_id].uActorHeight;
                     pSpellSprite.uAttributes = 0;
                     pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                     pSpellSprite.uSpriteFrameID = 0;
-                    pSpellSprite.spell_caster_pid =
-                        PID(OBJECT_Player, pCastSpell->uPlayerID);
+                    pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                     pSpellSprite.spell_target_pid = spell_targeted_at;
-                    pSpellSprite.field_60_distance_related_prolly_lod =
-                        target_direction.uDistance;
+                    pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                     pSpellSprite.uFacing = target_direction.uYawAngle;
                     pSpellSprite.uAttributes |= 0x80u;
                     pSpellSprite.uSoundID = pCastSpell->sound_id;
@@ -795,21 +761,19 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 break;
             }
 
-            case SPELL_DARK_SHRINKING_RAY:  //Сжимающий луч
+            case SPELL_DARK_SHRINKING_RAY:
             {
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 pSpellSprite.containing_item.Reset();
-                pSpellSprite.uObjectDescID =
-                    pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                 pSpellSprite.vPosition = pParty->vPosition + Vec3_int_(0, 0, pParty->uPartyHeight / 3);
                 pSpellSprite.uAttributes = 0;
                 pSpellSprite.uSectorID = pIndoor->GetSector(pSpellSprite.vPosition);
                 pSpellSprite.uSpriteFrameID = 0;
-                pSpellSprite.spell_caster_pid =
-                    PID(OBJECT_Player, pCastSpell->uPlayerID);
+                pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                 pSpellSprite.spell_target_pid = spell_targeted_at;
-                pSpellSprite.field_60_distance_related_prolly_lod =
-                    target_direction.uDistance;
+                pSpellSprite.field_60_distance_related_prolly_lod = target_direction.uDistance;
                 pSpellSprite.uFacing = target_direction.uYawAngle;
                 pSpellSprite.uSoundID = pCastSpell->sound_id;
                 pSpellSprite.spell_skill = skill_level;
@@ -817,19 +781,16 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 pSpellSprite.spell_level = 300 * spell_level;
                 if (pParty->bTurnBasedModeOn) {
                     pSpellSprite.uAttributes |= 4;
-                }
-                v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
-                if (pSpellSprite.Create(target_direction.uYawAngle,
-                    target_direction.uPitchAngle, v659,
-                    pCastSpell->uPlayerID + 1) != -1 &&
-                    pParty->bTurnBasedModeOn) {
-                    ++pTurnEngine->pending_actions;
+                    v659 = pObjectList->pObjects[pSpellSprite.uObjectDescID].uSpeed;
+                    if (pSpellSprite.Create(target_direction.uYawAngle, target_direction.uPitchAngle, v659, pCastSpell->uPlayerID + 1) != -1) {
+                        ++pTurnEngine->pending_actions;
+                    }
                 }
                 spell_sound_flag = true;
                 break;
             }
 
-            case SPELL_FIRE_FIRE_AURA:  //Аура огня
+            case SPELL_FIRE_FIRE_AURA:
             {
                 switch (skill_level) {
                     case 1:
@@ -851,13 +812,14 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     default:
                         assert(false);
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2]
-                             .pInventoryItemList[spell_targeted_at - 1];
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
+
+                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
                 _item = &pItemsTable->pItems[v730c->uItemID];
                 v730c->UpdateTempBonus(pParty->GetPlayingTime());
-                if (v730c->uItemID < 64 ||
-                    v730c->uItemID > 65 && !v730c->IsBroken() &&
+                if (v730c->uItemID < ITEM_BLASTER || v730c->uItemID > ITEM_LASER_RIFLE &&
+                        !v730c->IsBroken() &&
                         !v730c->special_enchantment &&
                         !v730c->uEnchantmentType &&
                         (_item->uEquipType == EQUIP_SINGLE_HANDED ||
@@ -866,9 +828,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         !pItemsTable->IsMaterialNonCommon(v730c)) {
                     v730c->special_enchantment = (ITEM_ENCHANTMENT)amount;
                     if (skill_level != 4) {
-                        v730c->uExpireTime =
-                            GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(spellduration));
+                        v730c->uExpireTime = GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration));
                         v730c->uAttributes |= ITEM_TEMP_BONUS;
                     }
                     v730c->uAttributes |= ITEM_AURA_EFFECT_RED;
@@ -906,21 +866,18 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 if (!pPlayer->CanCastSpell(uRequiredMana))
                     break;
                 spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                pParty->pPlayers[pCastSpell->uPlayerID_2]
-                    .pPlayerBuffs[PLAYER_BUFF_REGENERATION]
-                    .Apply(GameTime(pParty->GetPlayingTime() +
-                               GameTime::FromSeconds(3600 * spell_level)),
-                           skill_level, amount, 0, 0);
+                pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_REGENERATION]
+                    .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), skill_level, amount, 0, 0);
                 spell_sound_flag = true;
                 break;
             }
 
-            case SPELL_FIRE_PROTECTION_FROM_FIRE:  //Защита от Огня
-            case SPELL_AIR_PROTECTION_FROM_AIR:  //Звщита от Воздуха
-            case SPELL_WATER_PROTECTION_FROM_WATER:  //Защита от Воды
-            case SPELL_EARTH_PROTECTION_FROM_EARTH:  //Защита от Земли
-            case SPELL_MIND_PROTECTION_FROM_MIND:  //Защита от Мысли
-            case SPELL_BODY_PROTECTION_FROM_BODY:  //Защита от Тела
+            case SPELL_FIRE_PROTECTION_FROM_FIRE:
+            case SPELL_AIR_PROTECTION_FROM_AIR:
+            case SPELL_WATER_PROTECTION_FROM_WATER:
+            case SPELL_EARTH_PROTECTION_FROM_EARTH:
+            case SPELL_MIND_PROTECTION_FROM_MIND:
+            case SPELL_BODY_PROTECTION_FROM_BODY:
             {
                 switch (skill_level) {
                     case 1:
@@ -955,7 +912,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         assert(false);
                         continue;
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 spell_fx_renderer->SetPlayerBuffAnim(
                     pCastSpell->uSpellID, 0);
                 spell_fx_renderer->SetPlayerBuffAnim(
@@ -965,10 +923,7 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 spell_fx_renderer->SetPlayerBuffAnim(
                     pCastSpell->uSpellID, 3);
 
-                pParty->pPartyBuffs[buff_resist].Apply(
-                    GameTime(pParty->GetPlayingTime() +
-                        GameTime::FromSeconds(3600 * spell_level)),
-                    skill_level, amount, 0, 0);
+                pParty->pPartyBuffs[buff_resist].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(3600 * spell_level)), skill_level, amount, 0, 0);
                 spell_sound_flag = true;
                 break;
             }
@@ -994,30 +949,21 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 if (pPlayer->CanCastSpell(uRequiredMana)) {
                     spell_sound_flag = true;
                     for (uint pl_id = 0; pl_id < 4; pl_id++) {
-                        if (pParty->pPlayers[pl_id]
-                                .conditions_times[Condition_Weak]
-                                .Valid())
+                        if (pParty->pPlayers[pl_id].conditions_times[Condition_Weak].Valid())
                             spell_sound_flag = false;
                     }
                     if (spell_sound_flag) {
-                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(
-                            GameTime(pParty->GetPlayingTime() +
-                                GameTime::FromSeconds(spellduration)),
-                            skill_level, 0, 0, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 0);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 1);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 2);
-                        spell_fx_renderer->SetPlayerBuffAnim(
-                            pCastSpell->uSpellID, 3);
+                        pParty->pPartyBuffs[PARTY_BUFF_HASTE].Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), skill_level, 0, 0, 0);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 0);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 1);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 2);
+                        spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, 3);
                     }
                 }
                 break;
             }
 
-            case SPELL_SPIRIT_BLESS:  //Благословение
+            case SPELL_SPIRIT_BLESS:
             {
                 switch (skill_level) {
                     case 1:
@@ -1036,17 +982,13 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         assert(false);
                 }
                 amount = spell_level + 5;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 if (skill_level == 1) {
-                    spell_fx_renderer->SetPlayerBuffAnim(
-                        pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
-                    spell_overlay_id = pOtherOverlayList->_4418B1(
-                        10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
-                    pParty->pPlayers[pCastSpell->uPlayerID_2]
-                        .pPlayerBuffs[PLAYER_BUFF_BLESS]
-                        .Apply(GameTime(pParty->GetPlayingTime() +
-                                   GameTime::FromSeconds(spellduration)),
-                               1, amount, spell_overlay_id, 0);
+                    spell_fx_renderer->SetPlayerBuffAnim(pCastSpell->uSpellID, pCastSpell->uPlayerID_2);
+                    spell_overlay_id = pOtherOverlayList->_4418B1(10000, pCastSpell->uPlayerID_2 + 310, 0, 65536);
+                    pParty->pPlayers[pCastSpell->uPlayerID_2].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), 1, amount, spell_overlay_id, 0);
                     spell_sound_flag = true;
                     break;
                 }
@@ -1055,10 +997,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         pCastSpell->uSpellID, pl_id);
                     spell_overlay_id = pOtherOverlayList->_4418B1(
                         10000, pl_id + 310, 0, 65536);
-                    pParty->pPlayers[pl_id].pPlayerBuffs[1].Apply(
-                        GameTime(pParty->GetPlayingTime() +
-                            GameTime::FromSeconds(spellduration)),
-                        skill_level, amount, spell_overlay_id, 0);
+                    pParty->pPlayers[pl_id].pPlayerBuffs[PLAYER_BUFF_BLESS]
+                        .Apply(GameTime(pParty->GetPlayingTime() + GameTime::FromSeconds(spellduration)), skill_level, amount, spell_overlay_id, 0);
                 }
                 spell_sound_flag = true;
                 break;
@@ -1084,29 +1024,19 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                         pSpellSprite.spell_id = pCastSpell->uSpellID;
                         pSpellSprite.spell_level = spell_level;
                         pSpellSprite.spell_skill = skill_level;
-                        pSpellSprite.uObjectDescID =
-                            pObjectList->ObjectIDByItemID(pSpellSprite.uType);
+                        pSpellSprite.uObjectDescID = pObjectList->ObjectIDByItemID(pSpellSprite.uType);
                         pSpellSprite.uAttributes = 0;
                         pSpellSprite.uSectorID = 0;
                         pSpellSprite.uSpriteFrameID = 0;
                         pSpellSprite.field_60_distance_related_prolly_lod = 0;
-                        pSpellSprite.spell_caster_pid =
-                            PID(OBJECT_Player, pCastSpell->uPlayerID);
+                        pSpellSprite.spell_caster_pid = PID(OBJECT_Player, pCastSpell->uPlayerID);
                         pSpellSprite.uFacing = 0;
                         pSpellSprite.uSoundID = (short)pCastSpell->sound_id;
-                        pSpellSprite.vPosition.x =
-                            pActors[monster_id].vPosition.x;
-                        pSpellSprite.vPosition.y =
-                            pActors[monster_id].vPosition.y;
-                        pSpellSprite.vPosition.z =
-                            pActors[monster_id].vPosition.z -
-                            (int)((double)pActors[monster_id].uActorHeight *
-                                  -0.8);
-                        pSpellSprite.spell_target_pid =
-                            PID(OBJECT_Actor, spell_targeted_at);
-                        Actor::DamageMonsterFromParty(
-                            PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)),
-                            monster_id, &v701);
+                        pSpellSprite.vPosition.x = pActors[monster_id].vPosition.x;
+                        pSpellSprite.vPosition.y = pActors[monster_id].vPosition.y;
+                        pSpellSprite.vPosition.z = pActors[monster_id].vPosition.z - (int)((double)pActors[monster_id].uActorHeight * -0.8);
+                        pSpellSprite.spell_target_pid = PID(OBJECT_Actor, spell_targeted_at);
+                        Actor::DamageMonsterFromParty(PID(OBJECT_Item, pSpellSprite.Create(0, 0, 0, 0)), monster_id, &v701);
                         spell_sound_flag = true;
                     } else {
                         GameUI_SetStatusBar(LSTR_SPELL_FAILED);
@@ -1755,8 +1685,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
             case SPELL_WATER_RECHARGE_ITEM:
             {
                 if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[spell_targeted_at];
-                if (v730c->GetItemEquipType() != 12 || v730c->uAttributes & 2) {
+                v730c = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
+                if (v730c->GetItemEquipType() != EQUIP_WAND || v730c->uAttributes & 2) {
                     _50C9D0_AfterEnchClickEventId = 113;
                     _50C9D4_AfterEnchClickEventSecondParam = 0;
                     _50C9D8_AfterEnchClickEventTimeout = 1;
@@ -1795,14 +1725,16 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                 break;
             }
 
-            case SPELL_WATER_ENCHANT_ITEM: {  // Талисман
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+            case SPELL_WATER_ENCHANT_ITEM: {
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
+
                 uRequiredMana = 0;
                 amount = 10 * spell_level;
                 bool item_not_broken = true;
                 int rnd = rand() % 100;
                 pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID_2];
-                spell_item_to_enchant = &pPlayer->pInventoryItemList[spell_targeted_at - 1];
+                spell_item_to_enchant = &pPlayer->pInventoryItemList[pCastSpell->spell_target_pid];
                 ItemDesc *_v725 = &pItemsTable->pItems[spell_item_to_enchant->uItemID];
                 char this_equip_type = _v725->uEquipType;
 
@@ -1997,7 +1929,8 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     default:
                         assert(false);
                 }
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
                 if (pParty->pPlayers[pCastSpell->uPlayerID_2]
                         .conditions_times[Condition_Pertified]
                         .Valid()) {
@@ -2559,13 +2492,10 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
                     if (!pActors[monster_id].ActorHasItem())
                         pActors[monster_id].SetRandomGoldIfTheresNoItem();
                     int gold_num = 0;
-                    if (pItemsTable
-                            ->pItems
-                                [pActors[monster_id].ActorHasItems[3].uItemID]
-                            .uEquipType == EQUIP_GOLD)
-                        gold_num = pActors[monster_id]
-                                       .ActorHasItems[3]
-                                       .special_enchantment;
+                    if (pActors[monster_id].ActorHasItems[3].uItemID != 0) {
+                        if (pItemsTable->pItems[pActors[monster_id].ActorHasItems[3].uItemID].uEquipType == EQUIP_GOLD)
+                            gold_num = pActors[monster_id].ActorHasItems[3].special_enchantment;
+                    }
                     ItemGen item;
                     item.Reset();
                     if (pActors[monster_id].uCarriedItemID) {
@@ -3595,17 +3525,18 @@ void CastSpellInfoHelpers::_427E01_cast_spell() {
 
             case SPELL_DARK_VAMPIRIC_WEAPON:
             {
+                if (!pPlayer->CanCastSpell(uRequiredMana))
+                    break;
+
                 amount = 16;
                 if (skill_level == 4)
                     spellduration = 0;
                 else
                     spellduration = 3600 * spell_level;
-                if (!pPlayer->CanCastSpell(uRequiredMana)) break;
-                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2]
-                                     .pInventoryItemList[spell_targeted_at];
+
+                ItemGen *item = &pParty->pPlayers[pCastSpell->uPlayerID_2].pInventoryItemList[pCastSpell->spell_target_pid];
                 item->UpdateTempBonus(pParty->GetPlayingTime());
-                if (item->uItemID >= 64 && item->uItemID <= 65  // blasters
-                    || item->uAttributes & 2 ||
+                if (item->uItemID >= ITEM_BLASTER && item->uItemID <= ITEM_LASER_RIFLE || item->uAttributes & 2 ||
                     item->special_enchantment != 0 ||
                     item->uEnchantmentType != 0 ||
                     pItemsTable->pItems[item->uItemID].uEquipType != EQUIP_SINGLE_HANDED &&

--- a/GUI/GUIWindow.h
+++ b/GUI/GUIWindow.h
@@ -242,7 +242,7 @@ enum UIMessageType : uint32_t {
 
     UIMSG_DebugSpecialItem = 971,
     UIMSG_DebugGenItem = 972,
-    UIMSG_DebugFarClip = 973,
+    UIMSG_DebugVerboseLogging = 973,
     UIMSG_DebugSeasonsChange = 974,
     UIMSG_DebugShowFPS = 975,
     UIMSG_DebugPickedFace = 976,
@@ -252,7 +252,7 @@ enum UIMessageType : uint32_t {
     UIMSG_DebugNoDamage = 980,
     UIMSG_DebugFullHeal = 981,
     UIMSG_DebugSnow = 982,
-    UIMSG_DebugDrawDist = 983,
+    UIMSG_DebugExtendedDrawDistance = 983,
     UIMSG_DebugNoActors = 984,
     UIMSG_DebugTurboSpeed = 985,
     UIMSG_DebugLightmap = 986,

--- a/GUI/UI/UICharacter.cpp
+++ b/GUI/UI/UICharacter.cpp
@@ -3228,8 +3228,8 @@ void OnPaperdollLeftClick() {
         if (!pitem) return;
         // pPlayers[uActiveCharacter]->get
 
-        // enchanting??
-        if (_50C9A0_IsEnchantingInProgress) {  // наложить закл на экипировку
+        // enchant / recharge item
+        if (_50C9A0_IsEnchantingInProgress) {
             /* *((char *)pGUIWindow_CastTargetedSpell->ptr_1C + 8) &=
              *0x7Fu;//CastSpellInfo
              *((short *)pGUIWindow_CastTargetedSpell->ptr_1C + 2) =
@@ -3240,8 +3240,7 @@ void OnPaperdollLeftClick() {
             pSpellInfo = (CastSpellInfo *)pGUIWindow_CastTargetedSpell->ptr_1C;
             pSpellInfo->uFlags &= 0x7F;
             pSpellInfo->uPlayerID_2 = uActiveCharacter - 1;
-            pSpellInfo->spell_target_pid =
-                pPlayers[uActiveCharacter]->pEquipment.pIndices[pos];
+            pSpellInfo->spell_target_pid = pPlayers[uActiveCharacter]->pEquipment.pIndices[pos];
             pSpellInfo->field_6 = pEquipType;
 
             ptr_50C9A4_ItemToEnchant = pitem;
@@ -3254,8 +3253,7 @@ void OnPaperdollLeftClick() {
         } else {
             if (!ptr_50C9A4_ItemToEnchant) {  // снять вещь
                 pParty->SetHoldingItem(pitem);
-                pPlayers[uActiveCharacter]
-                    ->pEquipment.pIndices[pitem->uBodyAnchor - 1] = 0;
+                pPlayers[uActiveCharacter]->pEquipment.pIndices[pitem->uBodyAnchor - 1] = 0;
                 pitem->Reset();
 
                 // pParty->SetHoldingItem(&pPlayers[uActiveCharacter]->pInventoryItemList[v34

--- a/GUI/UI/UIGame.cpp
+++ b/GUI/UI/UIGame.cpp
@@ -2232,7 +2232,7 @@ GUIWindow_DebugMenu::GUIWindow_DebugMenu()
     GUIButton *pBtn_DebugLightMap = CreateButton(13, 221, width, height, 1, 0, UIMSG_DebugLightmap, 0, GameKey::None, "DEBUG TOGGLE LIGHTMAP DECAL");
     GUIButton *pBtn_DebugTurbo = CreateButton(127, 221, width, height, 1, 0, UIMSG_DebugTurboSpeed, 0, GameKey::None, "DEBUG TOGGLE TURBO SPEED");
     GUIButton *pBtn_DebugNoActors = CreateButton(241, 221, width, height, 1, 0, UIMSG_DebugNoActors, 0, GameKey::None, "DEBUG TOGGLE ACTORS");
-    GUIButton *pBtn_DebugDrawDist = CreateButton(354, 221, width, height, 1, 0, UIMSG_DebugDrawDist, 0, GameKey::None, "DEBUG TOGGLE EXTENDED DRAW DISTANCE");
+    GUIButton *pBtn_DebugExtendedDrawDistance = CreateButton(354, 221, width, height, 1, 0, UIMSG_DebugExtendedDrawDistance, 0, GameKey::None, "DEBUG TOGGLE EXTENDED DRAW DISTANCE");
 
     GUIButton *pBtn_DebugSnow = CreateButton(13, 248, width, height, 1, 0, UIMSG_DebugSnow, 0, GameKey::None, "DEBUG TOGGLE SNOW");
     GUIButton *pBtn_DebugPortalLines = CreateButton(127, 248, width, height, 1, 0, UIMSG_DebugPortalLines, 0, GameKey::None, "DEBUG TOGGLE PORTAL OUTLINES");
@@ -2240,7 +2240,7 @@ GUIWindow_DebugMenu::GUIWindow_DebugMenu()
     GUIButton *pBtn_DebugShowFPS = CreateButton(354, 248, width, height, 1, 0, UIMSG_DebugShowFPS, 0, GameKey::None, "DEBUG TOGGLE SHOW FPS");
 
     GUIButton *pBtn_DebugSeasonsChange = CreateButton(13, 275, width, height, 1, 0, UIMSG_DebugSeasonsChange, 0, GameKey::None, "DEBUG TOGGLE SEASONS CHANGE");
-    GUIButton *pBtn_DebugFarClipToggle = CreateButton(127, 275, width, height, 1, 0, UIMSG_DebugFarClip, 0, GameKey::None, "DEBUG TOGGLE FAR CLIP DISTANCE");
+    GUIButton *pBtn_DebugVerboseLogging = CreateButton(127, 275, width, height, 1, 0, UIMSG_DebugVerboseLogging, 0, GameKey::None, "DEBUG TOGGLE VERBOSE LOGGING");
     GUIButton *pBtn_DebugGenItem = CreateButton(241, 275, width, height, 1, 0, UIMSG_DebugGenItem, 0, GameKey::None, "DEBUG GENERATE RANDOM ITEM");
     GUIButton *pBtn_DebugSpecialItem = CreateButton(354, 275, width, height, 1, 0, UIMSG_DebugSpecialItem, 0, GameKey::None, "DEBUG GENERATE RANDOM SPECIAL ITEM");
 
@@ -2286,7 +2286,7 @@ void GUIWindow_DebugMenu::Update() {
     buttonbox(354, 248, "Show FPS", engine->config->show_fps);
 
     buttonbox(13, 275, "Seasons", engine->config->seasons_change);
-    buttonbox(127, 275, "Far Clip", engine->config->extended_draw_distance);
+    buttonbox(127, 275, "Verbose Log", engine->config->verbose_logging);
     buttonbox(241, 275, "Gen Item", 2);
     buttonbox(354, 275, "Special Item", 2);
 

--- a/GUI/UI/UIPopup.cpp
+++ b/GUI/UI/UIPopup.cpp
@@ -397,10 +397,10 @@ void GameUI_DrawItemInfo(struct ItemGen *inspect_item) {
                 pItemsTable
                 ->pSpecialEnchantments[inspect_item->special_enchantment - 1]
                 .pBonusStatement);
-        } else if (inspect_item->uNumCharges) {
+        } else if (inspect_item->GetItemEquipType() == EQUIP_WAND) {
             sprintf(
-                out_text + 200, "%s: %lu", localization->GetString(LSTR_CHARGES),
-                inspect_item->uNumCharges
+                out_text + 200, localization->GetString(LSTR_FMT_S_U_OUT_OF_U), localization->GetString(LSTR_CHARGES),
+                inspect_item->uNumCharges, inspect_item->uMaxCharges
             );
         }
     }
@@ -1024,12 +1024,14 @@ void MonsterPopup_Draw(unsigned int uActorID, GUIWindow *pWindow) {
     }
 
     // ps - test to track ai states
-    auto txttest = StringPrintf("%d", pActors[uActorID].uAIState);
-    pFontSmallnum->GetLineWidth(txttest);
-    pWindow->DrawTitleText(
-        pFontSmallnum, 0,
-        pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, 0, txttest,
-        3);
+    if (engine->config->verbose_logging) {
+        auto txttest = StringPrintf("AI State: %d", pActors[uActorID].uAIState);
+        pFontSmallnum->GetLineWidth(txttest);
+        pWindow->DrawTitleText(
+            pFontSmallnum, 0,
+            pWindow->uFrameHeight - pFontSmallnum->GetHeight() - 12, 0, txttest,
+            3);
+    }
 }
 
 //----- (00417BB5) --------------------------------------------------------
@@ -1270,11 +1272,9 @@ void CharacterUI_StatsTab_ShowHint() {
         case 15:  // Attack Bonus
             if (pAttackBonusAttributeDescription) {
                 int meleerecov = pPlayers[uActiveCharacter]->GetAttackRecoveryTime(false);
-                char recov[100];
-                sprintf(recov, "\n\nRecovery time: %d", meleerecov);
-                std::string test = std::string(pAttackBonusAttributeDescription) + std::string(recov);
-                CharacterUI_DrawTooltip(localization->GetString(LSTR_ATTACK_BONUS),
-                    /*pAttackBonusAttributeDescription*/test);
+                std::string description = StringPrintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), meleerecov);
+                description = StringPrintf("%s\n\n%s", pAttackBonusAttributeDescription, description.c_str());
+                CharacterUI_DrawTooltip(localization->GetString(LSTR_ATTACK_BONUS), description);
             }
             break;
 
@@ -1289,11 +1289,9 @@ void CharacterUI_StatsTab_ShowHint() {
         case 17:  // Missle Bonus
             if (pMissleBonusAttributeDescription) {
                 int missrecov = pPlayers[uActiveCharacter]->GetAttackRecoveryTime(true);
-                char recovm[100];
-                sprintf(recovm, "\n\nRecovery time: %d", missrecov);
-                std::string test2 = std::string(pAttackBonusAttributeDescription) + std::string(recovm);
-                CharacterUI_DrawTooltip(localization->GetString(LSTR_SHOOT_BONUS),
-                    /*pMissleBonusAttributeDescription*/test2);
+                std::string description = StringPrintf(localization->GetString(LSTR_FMT_RECOVERY_TIME_D), missrecov);
+                description = StringPrintf("%s\n\n%s", pAttackBonusAttributeDescription, description.c_str());
+                CharacterUI_DrawTooltip(localization->GetString(LSTR_SHOOT_BONUS), description);
             }
             break;
 

--- a/src/Application/Game.cpp
+++ b/src/Application/Game.cpp
@@ -2590,8 +2590,8 @@ void Game::EventLoop() {
                     engine->ToggleDebugNoActors();
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
                     continue;
-                case UIMSG_DebugDrawDist:
-                    engine->ToggleDebugDrawDist();
+                case UIMSG_DebugExtendedDrawDistance:
+                    engine->ToggleExtendedDrawDistance();
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
                     continue;
                 case UIMSG_DebugSnow:
@@ -2618,8 +2618,8 @@ void Game::EventLoop() {
                     engine->ToggleDebugSeasonsChange();
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
                     continue;
-                case UIMSG_DebugFarClip:
-                    engine->ToggleExtendedDrawDistance();
+                case UIMSG_DebugVerboseLogging:
+                    engine->ToggleVerboseLogging();
                     pAudioPlayer->PlaySound(SOUND_StartMainChoice02, 0, 0, -1, 0, 0);
                     continue;
                 default:


### PR DESCRIPTION
 * move our localization strings to the end of localization_strings for now.
 * show maximum number of charges for wands.
 * add logging for triggered event id.
 * repurpose "far clip" button in debug menu with verbose "logging". Hide tooltip ai state and floor/sector fails behind it.
 * disable autonotes and history books flashing on loading savefile.
 * fix wrong message when stealing gold.
 * fix vanilla's bug showing "Official" when you stole and item from npc.
 * fix unpatched vanilla's bug when stolen wands have 0 max charges and become unrechargable. Wands which spawn on the ground still needs to tested.
 * fix crash when you cast telepathy on npc which still has item, but all its gold was stolen.
 * fix bug when items in inventory or when equipped could not be recharged, enhanced, made vampiric or apply fire aura.
 * fix bug with spell autocast direction after we flipped camera pitch.
 * fix compare event processing for map variables, fixes for example aggro scripts in Castle Lambent.
 * fix #204: wrong quest table index and history story check.
 * fix #195: test patch for collision goto loop, needs testing