### PR TITLE
work on sky

### DIFF
--- a/Engine/Graphics/IRender.h
+++ b/Engine/Graphics/IRender.h
@@ -479,12 +479,12 @@ struct SkyBillboardStruct {
     float field_0_party_dir_x;  // cam view transform
     float field_4_party_dir_y;
     float field_8_party_dir_z;
-    float CamVecLeft_Z;
-    float CamVecLeft_X;
     float CamVecLeft_Y;
-    float CamVecFront_Z;
-    float CamVecFront_X;
+    float CamVecLeft_X;
+    float CamVecLeft_Z;
     float CamVecFront_Y;
+    float CamVecFront_X;
+    float CamVecFront_Z;
     float CamLeftDot;
     float CamFrontDot;
 };

--- a/Engine/Graphics/Image.h
+++ b/Engine/Graphics/Image.h
@@ -119,7 +119,7 @@ class TextureFrame {
     std::string name = "null";
     int16_t uAnimTime = 0;
     int16_t uAnimLength = 0;
-    int16_t uFlags = 0;
+    int16_t uFlags = 0;  // 1 for anim
 
     Texture *GetTexture();
 

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -506,10 +506,18 @@ void IndoorLocation::ExecDraw_d3d(unsigned int uFaceID,
         }
 
         // check if this face is visible through current portal node
-        if (pCamera3D->CullFaceToFrustum(static_vertices_buff_in, &uNumVerticesa, static_vertices_calc_out, portalfrustumnorm, 4)
+        if (pCamera3D->CullFaceToFrustum(static_vertices_buff_in, &uNumVerticesa, static_vertices_calc_out, portalfrustumnorm, 4)/* ||  true*/
             // pCamera3D->ClipFaceToFrustum(static_vertices_buff_in, &uNumVerticesa, static_vertices_calc_out, portalfrustumnorm, 4, 0, 0) || true
             ) {
             ++pBLVRenderParams->uNumFacesRenderedThisFrame;
+
+            /*for (uint i = 0; i < pFace->uNumVertices; ++i) {
+                static_vertices_calc_out[i].vWorldPosition.x = pIndoor->pVertices[pFace->pVertexIDs[i]].x;
+                static_vertices_calc_out[i].vWorldPosition.y = pIndoor->pVertices[pFace->pVertexIDs[i]].y;
+                static_vertices_calc_out[i].vWorldPosition.z = pIndoor->pVertices[pFace->pVertexIDs[i]].z;
+                static_vertices_calc_out[i].u = (signed short)pFace->pVertexUIDs[i];
+                static_vertices_calc_out[i].v = (signed short)pFace->pVertexVIDs[i];
+            }*/
 
             /*int xd = pParty->vPosition.x - pIndoor->pVertices[pFace->pVertexIDs[0]].x;
             int yd = pParty->vPosition.y - pIndoor->pVertices[pFace->pVertexIDs[0]].y;

--- a/Engine/Graphics/Polygon.h
+++ b/Engine/Graphics/Polygon.h
@@ -28,7 +28,7 @@ struct Polygon {
     float field_C = 0;
     float field_10 = 0;
     unsigned int uNumVertices;
-    Vec3_int_ v_18;
+    Vec3_int_ v_18;  // fp pitch rotation vec
     int field_24 = 0;  // dot dist
     int sTextureDeltaU = 0;
     int sTextureDeltaV = 0;

--- a/Engine/Graphics/Sprites.cpp
+++ b/Engine/Graphics/Sprites.cpp
@@ -41,7 +41,7 @@ void SpriteFrameTable::ResetLoadedFlags() {
 //----- (0044D513) --------------------------------------------------------
 void SpriteFrameTable::InitializeSprite(signed int uSpriteID) {
     // SpriteFrameTable *v2; // esi@1
-    unsigned int v3;  // ebx@3
+    //unsigned int iter_uSpriteID;  // ebx@3
     // char *v4; // edx@3
     // int v5; // eax@3
     //    SpriteFrame *v6; // ecx@5
@@ -68,27 +68,28 @@ void SpriteFrameTable::InitializeSprite(signed int uSpriteID) {
     // v2 = this;
     if (uSpriteID <= this->uNumSpriteFrames) {
         if (uSpriteID >= 0) {
-            v3 = uSpriteID;
+            uint iter_uSpriteID = uSpriteID;
+            //if (iter_uSpriteID == 807) __debugbreak();
 
-            int uFlags = pSpriteSFrames[v3].uFlags;
+            int uFlags = pSpriteSFrames[iter_uSpriteID].uFlags;
 
             if (!(uFlags & 0x0080)) {  // not loaded
-                pSpriteSFrames[v3].uFlags |= 0x80;  // set loaded
+                pSpriteSFrames[iter_uSpriteID].uFlags |= 0x80;  // set loaded
 
                 while (1) {
-                    pSpriteSFrames[v3].uPaletteIndex = pPaletteManager->LoadPalette(pSpriteSFrames[v3].uPaletteID);
+                    pSpriteSFrames[iter_uSpriteID].uPaletteIndex = pPaletteManager->LoadPalette(pSpriteSFrames[iter_uSpriteID].uPaletteID);
 
                     if (uFlags & 0x10) {  // single frame per frame sequence
-                        auto v8 = pSprites_LOD->LoadSprite(pSpriteSFrames[v3].texture_name.c_str(), pSpriteSFrames[v3].uPaletteID);
+                        auto v8 = pSprites_LOD->LoadSprite(pSpriteSFrames[iter_uSpriteID].texture_name.c_str(), pSpriteSFrames[iter_uSpriteID].uPaletteID);
 
                         if (v8 == -1) {
-                            logger->Warning("Sprite %s not loaded!", pSpriteSFrames[v3].texture_name.c_str());
+                            logger->Warning("Sprite %s not loaded!", pSpriteSFrames[iter_uSpriteID].texture_name.c_str());
                             for (uint i = 0; i < 8; ++i) {
-                                pSpriteSFrames[v3].hw_sprites[i] = nullptr;
+                                pSpriteSFrames[iter_uSpriteID].hw_sprites[i] = nullptr;
                             }
                         } else {
                             for (uint i = 0; i < 8; ++i) {
-                                pSpriteSFrames[v3].hw_sprites[i] = &pSprites_LOD->pHardwareSprites[v8];
+                                pSpriteSFrames[iter_uSpriteID].hw_sprites[i] = &pSprites_LOD->pHardwareSprites[v8];
                             }
                         }
 
@@ -99,41 +100,41 @@ void SpriteFrameTable::InitializeSprite(signed int uSpriteID) {
                                 case 4:
                                 case 5:
                                     sprintf(sprite_name, "%s4",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                                 case 2:
                                 case 6:
                                     sprintf(sprite_name, "%s2",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                                 case 0:
                                 case 1:
                                 case 7:
                                     sprintf(sprite_name, "%s0",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                             }
                             auto v12 = pSprites_LOD->LoadSprite(
-                                sprite_name, pSpriteSFrames[v3].uPaletteID);
-                            // pSpriteSFrames[v3].pHwSpriteIDs[i]=v12;
+                                sprite_name, pSpriteSFrames[iter_uSpriteID].uPaletteID);
+                            // pSpriteSFrames[iter_uSpriteID].pHwSpriteIDs[i]=v12;
                             if (v12 == -1) __debugbreak();
-                            pSpriteSFrames[v3].hw_sprites[i] =
+                            pSpriteSFrames[iter_uSpriteID].hw_sprites[i] =
                                 &pSprites_LOD->pHardwareSprites[v12];
                         }
 
                     } else if (uFlags & 0x40) {  // part of monster fidgeting seq
                         strcpy(Source, "stA");
-                        strcpy(Str, pSpriteSFrames[v3].texture_name.c_str());
+                        strcpy(Str, pSpriteSFrames[iter_uSpriteID].texture_name.c_str());
                         auto v14 = strlen(Str);
                         strcpy(&Str[v14 - 3], Source);
                         for (uint i = 0; i < 8; ++i) {
                             switch (i) {
                                 case 0:
                                     sprintf(sprite_name, "%s0",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                                 case 4:
@@ -146,87 +147,87 @@ void SpriteFrameTable::InitializeSprite(signed int uSpriteID) {
                                 case 2:
                                 case 6:
                                     sprintf(sprite_name, "%s2",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                                 case 1:
                                 case 7:
                                     sprintf(sprite_name, "%s1",
-                                            pSpriteSFrames[v3]
+                                            pSpriteSFrames[iter_uSpriteID]
                                                 .texture_name.c_str());
                                     break;
                             }
                             auto v12 = pSprites_LOD->LoadSprite(
-                                sprite_name, pSpriteSFrames[v3].uPaletteID);
-                            // pSpriteSFrames[v3].pHwSpriteIDs[i]=v12;
+                                sprite_name, pSpriteSFrames[iter_uSpriteID].uPaletteID);
+                            // pSpriteSFrames[iter_uSpriteID].pHwSpriteIDs[i]=v12;
                             if (v12 == -1) __debugbreak();
 
-                            pSpriteSFrames[v3].hw_sprites[i] =
+                            pSpriteSFrames[iter_uSpriteID].hw_sprites[i] =
                                 &pSprites_LOD->pHardwareSprites[v12];
                         }
                     } else {
                         for (uint i = 0; i < 8; ++i) {
                             if (((0x0100 << i) &
-                                 pSpriteSFrames[v3].uFlags)) {  // mirrors
+                                 pSpriteSFrames[iter_uSpriteID].uFlags)) {  // mirrors
                                 switch (i) {
                                     case 1:
                                         sprintf(sprite_name, "%s7",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 2:
                                         sprintf(sprite_name, "%s6",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 3:
                                         sprintf(sprite_name, "%s5",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 4:
                                         sprintf(sprite_name, "%s4",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 5:
                                         sprintf(sprite_name, "%s3",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 6:
                                         sprintf(sprite_name, "%s2",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                     case 7:
                                         sprintf(sprite_name, "%s1",
-                                                pSpriteSFrames[v3]
+                                                pSpriteSFrames[iter_uSpriteID]
                                                     .texture_name.c_str());
                                         break;
                                 }
                             } else {
                                 // some names already passed through with codes attached
-                                if (strlen(pSpriteSFrames[v3].texture_name.c_str()) < 7) {
-                                    sprintf(sprite_name, "%s%i", pSpriteSFrames[v3].texture_name.c_str(), i);
+                                if (strlen(pSpriteSFrames[iter_uSpriteID].texture_name.c_str()) < 7) {
+                                    sprintf(sprite_name, "%s%i", pSpriteSFrames[iter_uSpriteID].texture_name.c_str(), i);
                                 } else {
-                                    sprintf(sprite_name, "%s", pSpriteSFrames[v3].texture_name.c_str());
+                                    sprintf(sprite_name, "%s", pSpriteSFrames[iter_uSpriteID].texture_name.c_str());
                                     // __debugbreak();
                                 }
                             }
 
-                            auto v12 = pSprites_LOD->LoadSprite(sprite_name, pSpriteSFrames[v3].uPaletteID);
-                            // pSpriteSFrames[v3].pHwSpriteIDs[i]=v12;
+                            auto v12 = pSprites_LOD->LoadSprite(sprite_name, pSpriteSFrames[iter_uSpriteID].uPaletteID);
+                            // pSpriteSFrames[iter_uSpriteID].pHwSpriteIDs[i]=v12;
 
                             if (v12 == -1) __debugbreak();
 
-                            pSpriteSFrames[v3].hw_sprites[i] =
+                            pSpriteSFrames[iter_uSpriteID].hw_sprites[i] =
                                 &pSprites_LOD->pHardwareSprites[v12];
                         }
                     }
 
-                    if (!(pSpriteSFrames[v3].uFlags & 1)) return;
-                    ++v3;
+                    if (!(pSpriteSFrames[iter_uSpriteID].uFlags & 1)) return;
+                    ++iter_uSpriteID;
                 }
             }
         }
@@ -265,12 +266,17 @@ SpriteFrame *SpriteFrameTable::GetFrame(unsigned int uSpriteID, unsigned int uTi
     SpriteFrame *v4 = &pSpriteSFrames[uSpriteID];
     if (~v4->uFlags & 1 || !v4->uAnimLength) return pSpriteSFrames + uSpriteID;
 
+
+    // uAnimLength / uAnimTime = actual number of frames in sprite
     for (uint t = (uTime / 8) % v4->uAnimLength; t > v4->uAnimTime; ++v4)
         t -= v4->uAnimTime;
 
-    // TODO(pskelton): investigate and fix properly
+    // TODO(pskelton): investigate and fix properly - dragon breath is missing last two frames??
     // quick fix so it doesnt return empty sprite
-     while (v4->hw_sprites[0] == NULL) --v4;
+    while (v4->hw_sprites[0] == NULL) {
+        __debugbreak();
+        --v4;
+    }
 
     return v4;
 

--- a/Engine/Graphics/Sprites.h
+++ b/Engine/Graphics/Sprites.h
@@ -46,7 +46,7 @@ class SpriteFrame {
 
     Sprite* hw_sprites[8] {};
     float scale = 1.0;
-    int uFlags = 0;  // 128 for loaded
+    int uFlags = 0;  // 128 for loaded - 1 for anim
     int uGlowRadius = 0;
     int uPaletteID = 0;
     int uPaletteIndex = 0;


### PR DESCRIPTION
Fixes d3d sky indoors and outdoors
Fixes GL sky outdoors and adds workaround for indoors for now.

There is a load of code at the bottom of the sky calcs I havnt deleted yet. Wanted further testing to make sure its never reached.


Also spell "Dragonbreath" appears to be missing two animation sprites??