### PR TITLE
pixel literal format cleanup

### DIFF
--- a/Engine/Graphics/Image.cpp
+++ b/Engine/Graphics/Image.cpp
@@ -289,26 +289,26 @@ const void *Image::GetPixels(IMAGE_FORMAT format) {
                         nullptr,                   // IMAGE_FORMAT_R5G6B5
                         nullptr,                   // IMAGE_FORMAT_A1R5G5B5
                         Image_R5G6B5_to_A8R8G8B8,  // IMAGE_FORMAT_A8R8G8B8
-                        Image_R5G6B5_to_R8G8B8,    // IMAGE_FORMAT_R8G8B8
-                        Image_R5G6B5_to_R8G8B8A8,                   // IMAGE_FORMAT_R8G8B8A8
+                        nullptr,    // IMAGE_FORMAT_R8G8B8
+                        nullptr,                   // IMAGE_FORMAT_R8G8B8A8
                     },
 
                     // IMAGE_FORMAT_A1R5G5B5 ->
                     {
                         nullptr,                     // IMAGE_FORMAT_R5G6B5
                         nullptr,                     // IMAGE_FORMAT_A1R5G5B5
-                        nullptr,                     // IMAGE_FORMAT_A8R8G8B8
+                        Image_A1R5G5B5_to_A8R8G8B8,  // IMAGE_FORMAT_A8R8G8B8
                         nullptr,                     // IMAGE_FORMAT_R8G8B8
-                        Image_A1R5G5B5_to_R8G8B8A8,  // IMAGE_FORMAT_R8G8B8A8
+                        nullptr,                     // IMAGE_FORMAT_R8G8B8A8
                     },
 
                     // IMAGE_FORMAT_A8R8G8B8 ->
                     {
-                        Image_A8R8G8B8_to_R5G6B5,  // IMAGE_FORMAT_R5G6B5
-                        Image_A8R8G8B8_to_A1R5G5B5,  // IMAGE_FORMAT_A1R5G5B5
+                        nullptr,                    // IMAGE_FORMAT_R5G6B5
+                        Image_A8R8G8B8_to_A1R5G5B5, // IMAGE_FORMAT_A1R5G5B5
                         nullptr,                   // IMAGE_FORMAT_A8R8G8B8
                         nullptr,                   // IMAGE_FORMAT_R8G8B8
-                        Image_A8R8G8B8_to_R8G8B8A8,       // IMAGE_FORMAT_R8G8B8A8
+                        nullptr,                   // IMAGE_FORMAT_R8G8B8A8
                     },
 
                     // IMAGE_FORMAT_R8G8B8 ->
@@ -322,9 +322,9 @@ const void *Image::GetPixels(IMAGE_FORMAT format) {
 
                     // IMAGE_FORMAT_R8G8B8A8 ->
                     {
-                        Image_R8G8B8A8_to_R5G6B5,  // IMAGE_FORMAT_R5G6B5
+                        nullptr,                 // IMAGE_FORMAT_R5G6B5
                         nullptr,                   // IMAGE_FORMAT_A1R5G5B5
-                        Image_R8G8B8A8_to_A8R8G8B8,     // IMAGE_FORMAT_A8R8G8B8
+                        nullptr,                  // IMAGE_FORMAT_A8R8G8B8
                         nullptr,                   // IMAGE_FORMAT_R8G8B8
                         nullptr,                   // IMAGE_FORMAT_R8G8B8A8
                     },
@@ -338,6 +338,8 @@ const void *Image::GetPixels(IMAGE_FORMAT format) {
                     new unsigned char[num_pixels *
                                       IMAGE_FORMAT_BytesPerPixel(format)];
                 if (cvt(width * height, native_pixels, cvt_pixels)) {
+                    if (engine->config->verbose_logging)
+                        logger->Info("Image pixel format conversion");
                     return this->pixels[format] = cvt_pixels;
                 } else {
                     delete[] cvt_pixels;

--- a/Engine/Graphics/ImageFormatConverter.h
+++ b/Engine/Graphics/ImageFormatConverter.h
@@ -1,7 +1,6 @@
 #pragma once
 
-typedef bool (*ImageFormatConverter)(unsigned int num_pixels, const void *src,
-                                     void *dst);
+typedef bool (*ImageFormatConverter)(unsigned int num_pixels, const void *src, void *dst);
 
 inline uint32_t R5G6B5_to_A8R8G8B8(uint16_t color16, unsigned char alpha) {
     uint32_t c = color16;
@@ -12,110 +11,7 @@ inline uint32_t R5G6B5_to_A8R8G8B8(uint16_t color16, unsigned char alpha) {
     return ((unsigned int)alpha << 24) | (r << 16) | (g << 8) | b;
 }
 
-inline uint32_t R5G6B5_to_R8G8B8A8(uint16_t color16, unsigned char alpha) {  // eh what?? ABGR
-    uint32_t c = color16;
-    unsigned int b = (c & 31) * 8;
-    unsigned int g = ((c >> 5) & 63) * 4;
-    unsigned int r = ((c >> 11) & 31) * 8;
-
-    return (((unsigned int)alpha << 24) & 0xFF000000) | ((b << 16) & 0x00FF0000) | ((g << 8) & 0x0000FF00) | (r & 0x000000FF);
-}
-
-inline uint16_t A8R8G8B8_to_R5G6B5(uint32_t c) {
-    uint32_t b = ((c & 0xFF) / 8) & 31;
-    uint32_t g = (((c >> 8) & 0xFF) / 4) & 63;
-    uint32_t r = (((c >> 16) & 0xFF) / 8) & 31;
-
-    return (uint16_t)((r << 11) | (g << 5) | b);
-}
-
-inline uint16_t A8R8G8B8_to_A1R5G5B5(uint32_t c) {
-    uint32_t b = ((c & 0xFF) / 8) & 31;
-    uint32_t g = (((c >> 8) & 0xFF) / 8) & 31;
-    uint32_t r = (((c >> 16) & 0xFF) / 8) & 31;
-    uint32_t a = (((c >> 24) & 0xFF)) == 255;
-
-    return (uint16_t)( (a << 15) |(r << 10) | (g << 5) | b);
-}
-
-
-inline uint32_t A8R8G8B8_to_R8G8B8A8(uint32_t c) {  // eh waht ?? ABGR
-    return (c & 0xFF000000) | (c & 0x000000FF) << 16 | (c & 0x0000FF00) | (c & 0x00FF0000) >> 16;
-}
-
-inline bool Image_A8R8G8B8_to_R8G8B8A8(unsigned int num_pixels, const void *src_pixels, void *dst_pixels) {
-    auto src = (uint32_t*)src_pixels;
-    auto dst = (uint32_t*)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = A8R8G8B8_to_R8G8B8A8(src[i]);
-    }
-
-    return true;
-}
-
-inline uint32_t R8G8B8A8_to_A8R8G8B8(uint32_t c) {  // eh waht ?? ABGR
-    return (c & 0xFF000000) | (c & 0x000000FF) << 16 | (c & 0x0000FF00) | (c & 0x00FF0000) >> 16;
-}
-
-inline bool Image_R8G8B8A8_to_A8R8G8B8(unsigned int num_pixels, const void *src_pixels, void *dst_pixels) {
-    auto src = (uint32_t *)src_pixels;
-    auto dst = (uint32_t *)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = R8G8B8A8_to_A8R8G8B8(src[i]);
-    }
-
-    return true;
-}
-
-inline bool Image_A8R8G8B8_to_R5G6B5(unsigned int num_pixels,
-                                     const void *src_pixels, void *dst_pixels) {
-    auto src = (uint32_t*)src_pixels;
-    auto dst = (uint16_t*)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = A8R8G8B8_to_R5G6B5(src[i]);
-    }
-
-    return true;
-}
-
-inline bool Image_A8R8G8B8_to_A1R5G5B5(unsigned int num_pixels,
-    const void *src_pixels, void *dst_pixels) {
-
-    auto src = (uint32_t*)src_pixels;
-    auto dst = (uint16_t*)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = A8R8G8B8_to_A1R5G5B5(src[i]);
-    }
-
-    return true;
-}
-
-inline uint16_t R8G8B8A8_to_R5G6B5(uint32_t c) {
-    uint32_t b = (((c >> 16) & 0xFF) / 8) & 31;
-    uint32_t g = (((c >> 8) & 0xFF) / 4) & 63;
-    uint32_t r = (((c) & 0xFF) / 8) & 31;
-
-    return (uint16_t)((r << 11) | (g << 5) | b);
-}
-
-inline bool Image_R8G8B8A8_to_R5G6B5(unsigned int num_pixels,
-    const void *src_pixels, void *dst_pixels) {
-    auto src = (uint32_t *)src_pixels;
-    auto dst = (uint16_t *)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = R8G8B8A8_to_R5G6B5(src[i]);
-    }
-
-    return true;
-}
-
-inline bool Image_R5G6B5_to_A8R8G8B8(unsigned int num_pixels,
-                                     const void *src_pixels, void *dst_pixels) {
+inline bool Image_R5G6B5_to_A8R8G8B8(unsigned int num_pixels, const void *src_pixels, void *dst_pixels) {
     auto src = (uint16_t*)src_pixels;
     auto dst = (uint32_t*)dst_pixels;
 
@@ -126,41 +22,29 @@ inline bool Image_R5G6B5_to_A8R8G8B8(unsigned int num_pixels,
     return true;
 }
 
-inline bool Image_R5G6B5_to_R8G8B8A8(unsigned int num_pixels,
-    const void *src_pixels, void *dst_pixels) {
-    auto src = (uint16_t*)src_pixels;
-    auto dst = (uint32_t*)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i] = R5G6B5_to_R8G8B8A8(src[i], 255);
-    }
-
-    return true;
-}
-
-inline unsigned int R5G6B5_extract_R(uint16_t c) {
-    return 8 * ((c >> 11) & 0x1F);
-}
-inline unsigned int R5G6B5_extract_G(uint16_t c) {
-    return 4 * ((c >> 5) & 0x3F);
-}
-inline unsigned int R5G6B5_extract_B(uint16_t c) {
-    return 8 * ((c >> 0) & 0x1F);
-}
-
-inline bool Image_R5G6B5_to_R8G8B8(unsigned int num_pixels,
-                                   const void *src_pixels, void *dst_pixels) {
-    auto src = (uint16_t*)src_pixels;
-    auto dst = (uint8_t*)dst_pixels;
-
-    for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i * 3 + 0] = R5G6B5_extract_R(src[i]);
-        dst[i * 3 + 1] = R5G6B5_extract_G(src[i]);
-        dst[i * 3 + 2] = R5G6B5_extract_B(src[i]);
-    }
-
-    return true;
-}
+//inline unsigned int R5G6B5_extract_R(uint16_t c) {
+//    return 8 * ((c >> 11) & 0x1F);
+//}
+//inline unsigned int R5G6B5_extract_G(uint16_t c) {
+//    return 4 * ((c >> 5) & 0x3F);
+//}
+//inline unsigned int R5G6B5_extract_B(uint16_t c) {
+//    return 8 * ((c >> 0) & 0x1F);
+//}
+//
+//inline bool Image_R5G6B5_to_R8G8B8(unsigned int num_pixels,
+//                                   const void *src_pixels, void *dst_pixels) {
+//    auto src = (uint16_t*)src_pixels;
+//    auto dst = (uint8_t*)dst_pixels;
+//
+//    for (unsigned int i = 0; i < num_pixels; ++i) {
+//        dst[i * 3 + 0] = R5G6B5_extract_R(src[i]);
+//        dst[i * 3 + 1] = R5G6B5_extract_G(src[i]);
+//        dst[i * 3 + 2] = R5G6B5_extract_B(src[i]);
+//    }
+//
+//    return true;
+//}
 
 inline unsigned int A1R5G5B5_extract_A(uint16_t c) {
     return c & 0x8000 ? 255 : 0;
@@ -175,17 +59,39 @@ inline unsigned int A1R5G5B5_extract_B(uint16_t c) {
     return 8 * ((c >> 0) & 0x1F);
 }
 
-inline bool Image_A1R5G5B5_to_R8G8B8A8(unsigned int num_pixels,
-                                       const void *src_pixels,
-                                       void *dst_pixels) {
-    auto src = (uint16_t*)src_pixels;
-    auto dst = (uint8_t*)dst_pixels;
+inline bool Image_A1R5G5B5_to_A8R8G8B8(unsigned int num_pixels,
+    const void *src_pixels,
+    void *dst_pixels) {
+    auto src = (uint16_t *)src_pixels;
+    auto dst = (uint8_t *)dst_pixels;
 
     for (unsigned int i = 0; i < num_pixels; ++i) {
-        dst[i * 4 + 0] = A1R5G5B5_extract_R(src[i]);
+        dst[i * 4 + 2] = A1R5G5B5_extract_R(src[i]);
         dst[i * 4 + 1] = A1R5G5B5_extract_G(src[i]);
-        dst[i * 4 + 2] = A1R5G5B5_extract_B(src[i]);
+        dst[i * 4 + 0] = A1R5G5B5_extract_B(src[i]);
         dst[i * 4 + 3] = A1R5G5B5_extract_A(src[i]);
+    }
+
+    return true;
+}
+
+inline uint16_t A8R8G8B8_to_A1R5G5B5(uint32_t c) {
+    uint32_t b = ((c & 0xFF) / 8) & 31;
+    uint32_t g = (((c >> 8) & 0xFF) / 8) & 31;
+    uint32_t r = (((c >> 16) & 0xFF) / 8) & 31;
+    uint32_t a = (((c >> 24) & 0xFF)) == 255;
+
+    return (uint16_t)((a << 15) | (r << 10) | (g << 5) | b);
+}
+
+inline bool Image_A8R8G8B8_to_A1R5G5B5(unsigned int num_pixels,
+    const void *src_pixels, void *dst_pixels) {
+
+    auto src = (uint32_t *)src_pixels;
+    auto dst = (uint16_t *)dst_pixels;
+
+    for (unsigned int i = 0; i < num_pixels; ++i) {
+        dst[i] = A8R8G8B8_to_A1R5G5B5(src[i]);
     }
 
     return true;

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -183,7 +183,7 @@ bool Alpha_LOD_Loader::Load(unsigned int *out_width, unsigned int *out_height,
 bool PCX_Loader::InternalLoad(void *file, size_t filesize,
                                    unsigned int *width, unsigned int *height,
                                    void **pixels, IMAGE_FORMAT *format) {
-    IMAGE_FORMAT request_format = IMAGE_FORMAT_R8G8B8A8;
+    IMAGE_FORMAT request_format = IMAGE_FORMAT_A8R8G8B8;
     if (engine->config->renderer_name == "DirectDraw")
         request_format = IMAGE_FORMAT_R5G6B5;
 

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1969,8 +1969,9 @@ bool RenderOpenGL::MoveTextureToDevice(Texture *texture) {
 
     unsigned __int8 *pixels = nullptr;
     if (native_format == IMAGE_FORMAT_R5G6B5 || native_format == IMAGE_FORMAT_A1R5G5B5 || native_format == IMAGE_FORMAT_A8R8G8B8 || native_format == IMAGE_FORMAT_R8G8B8A8) {
-        pixels = (unsigned __int8 *)t->GetPixels(IMAGE_FORMAT_R8G8B8A8);  // rgba
-        gl_format = GL_RGBA;
+        pixels = (unsigned __int8 *)t->GetPixels(IMAGE_FORMAT_A8R8G8B8);
+        // takes care of endian flip from literals here - hence BGRA
+        gl_format = GL_BGRA;
     } else {
         log->Warning("Image not loaded!");
     }
@@ -1981,7 +1982,7 @@ bool RenderOpenGL::MoveTextureToDevice(Texture *texture) {
         t->SetOpenGlTexture(texid);
 
         glBindTexture(GL_TEXTURE_2D, texid);
-        glTexImage2D(GL_TEXTURE_2D, 0, gl_format, t->GetWidth(), t->GetHeight(),
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, t->GetWidth(), t->GetHeight(),
                      0, gl_format, GL_UNSIGNED_BYTE, pixels);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -4281,15 +4282,16 @@ void RenderOpenGL::NuklearFontFree(struct nk_tex_font *tfont) {
 struct nk_image RenderOpenGL::NuklearImageLoad(Image *img) {
     GLuint texid;
     auto t = (TextureOpenGL *)img;
-    unsigned __int8 *pixels = (unsigned __int8 *)t->GetPixels(IMAGE_FORMAT_R8G8B8A8);
+    //unsigned __int8 *pixels = (unsigned __int8 *)t->GetPixels(IMAGE_FORMAT_A8R8G8B8);
+    texid = t->GetOpenGlTexture();
 
-    glGenTextures(1, &texid);
+    //glGenTextures(1, &texid);
     t->SetOpenGlTexture(texid);
-    glBindTexture(GL_TEXTURE_2D, texid);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, t->GetWidth(), t->GetHeight(), 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    //glBindTexture(GL_TEXTURE_2D, texid);
+    //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    //glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, t->GetWidth(), t->GetHeight(), 0, /*GL_RGBA*/GL_BGRA, GL_UNSIGNED_BYTE, pixels);
+    //glBindTexture(GL_TEXTURE_2D, 0);
 
     return nk_image_id(texid);
 }

--- a/Engine/Graphics/PCX.cpp
+++ b/Engine/Graphics/PCX.cpp
@@ -118,7 +118,7 @@ uint8_t *PCX::Decode(const void *pcx_data, size_t filesize, unsigned int *width,
             if (requested_format == IMAGE_FORMAT_R5G6B5)
                 *format = IMAGE_FORMAT_R5G6B5;
             else
-                *format = IMAGE_FORMAT_R8G8B8A8;
+                *format = IMAGE_FORMAT_A8R8G8B8;
 
             break;
         case 0x0108:
@@ -178,9 +178,9 @@ uint8_t *PCX::Decode(const void *pcx_data, size_t filesize, unsigned int *width,
                     pixels[stride + 2 * x] = tmp & 0xff;
                     pixels[stride + 2 * x + 1] = tmp >> 8;
                 } else {
-                    pixels[stride + 4 * x] = scanline[x];
+                    pixels[stride + 4 * x + 2] = scanline[x];
                     pixels[stride + 4 * x + 1] = scanline[x + header->bytes_per_row];
-                    pixels[stride + 4 * x + 2] = scanline[x + (header->bytes_per_row << 1)];
+                    pixels[stride + 4 * x + 0] = scanline[x + (header->bytes_per_row << 1)];
                     pixels[stride + 4 * x + 3] = 255;
                 }
             }

--- a/Engine/SaveLoad.cpp
+++ b/Engine/SaveLoad.cpp
@@ -380,12 +380,12 @@ void SaveGame(bool IsAutoSAve, bool NotSaveWorld) {
             LloydBeacon *beacon = &player->vBeacons[j];
             Image *image = beacon->image;
             if ((beacon->uBeaconTime != 0) && (image != nullptr)) {
-                const void *pixels = image->GetPixels(IMAGE_FORMAT_R5G6B5);
+                const void *pixels = image->GetPixels(IMAGE_FORMAT_A8R8G8B8);
                 if (!pixels)
                     __debugbreak();
                 unsigned int pcx_data_size = 30000;
                 void *pcx_data = malloc(pcx_data_size);
-                PCX::Encode16(pixels, image->GetWidth(), image->GetHeight(),
+                PCX::Encode32(pixels, image->GetWidth(), image->GetHeight(),
                               pcx_data, pcx_data_size, &pcx_data_size);
                 std::string str = StringPrintf("lloyd%d%d.pcx", i + 1, j + 1);
                 if (pNew_LOD->Write(str, pcx_data, pcx_data_size, 0)) {


### PR DESCRIPTION
Forces more consistent use of colour literals fixes #240.
A8R8G8B8 - > 0xAARRGGBB ect
Swizzle handled during pixel data upload