### PR TITLE
More fixes

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -16,17 +16,17 @@ jobs:
         fetch-depth: 0
     - name: Install
       run: |
-        export CC=gcc-9 && export CXX=g++-9
+        export CC=gcc-10 && export CXX=g++-10
         git submodule update --init
         mkdir out && cd out
         if [ "${{ matrix.Platform }}" = "x64" ]; then
-        sudo apt-get update && sudo apt-get install -y gcc-8 g++-8 libglu1-mesa-dev libavformat-dev libavcodec-dev libswscale-dev libopenal-dev libsdl2-dev zlib1g-dev
+        sudo apt-get update && sudo apt-get install -y gcc-10 g++-10 libglu1-mesa-dev libavformat-dev libavcodec-dev libswscale-dev libopenal-dev libsdl2-dev zlib1g-dev
         cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }}
         fi
         if [ "${{ matrix.Platform }}" = "x86" ]; then
         export libxml2_ver=2.9.4+dfsg1-6.1ubuntu1.3
         sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y libxml2=$libxml2_ver libxml2-dev=$libxml2_ver libxml2:i386=$libxml2_ver
-        sudo apt-get install -y gcc-multilib g++-8-multilib libglu1-mesa-dev:i386 libavformat-dev:i386 libavcodec-dev:i386 libswscale-dev:i386 libopenal-dev:i386 libsdl2-dev:i386 zlib1g-dev:i386
+        sudo apt-get install -y gcc-multilib g++-10-multilib libglu1-mesa-dev:i386 libavformat-dev:i386 libavcodec-dev:i386 libswscale-dev:i386 libopenal-dev:i386 libsdl2-dev:i386 zlib1g-dev:i386
         CFLAGS="-m32" CXXFLAGS="-m32" cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }}
         fi
     - name: Build

--- a/Engine/Graphics/BSPModel.cpp
+++ b/Engine/Graphics/BSPModel.cpp
@@ -9,6 +9,7 @@
 #include "Engine/Graphics/Image.h"
 #include "Engine/Time.h"
 #include "Engine/Graphics/Indoor.h"
+#include "Engine/VectorTypes.h"
 
 #pragma pack(push, 1)
 struct ODMFace_MM7 {
@@ -26,7 +27,7 @@ struct ODMFace_MM7 {
     int16_t uTextureID;
     int16_t sTextureDeltaU;
     int16_t sTextureDeltaV;
-    struct BBox_short_ pBoundingBox;
+    BBox_short_ pBoundingBox;
     int16_t sCogNumber;
     int16_t sCogTriggeredID;
     int16_t sCogTriggerType;

--- a/Engine/Graphics/BSPModel.h
+++ b/Engine/Graphics/BSPModel.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <string>
 
-#include "../VectorTypes.h"
+#include "Engine/VectorTypes.h"
 
 #define FACE_IsPortal           0x00000001
 #define FACE_IsSecret           0x00000002
@@ -156,7 +156,7 @@ struct ODMFace {
 
     int16_t sTextureDeltaU = 0;
     int16_t sTextureDeltaV = 0;
-    struct BBox_short_ pBoundingBox {};
+    BBox_short_ pBoundingBox;
     int16_t sCogNumber = 0;
     int16_t sCogTriggeredID = 0;
     int16_t sCogTriggerType = 0;

--- a/Engine/Graphics/Camera.cpp
+++ b/Engine/Graphics/Camera.cpp
@@ -658,11 +658,6 @@ void Camera3D::CalculateRotations(int camera_rot_y, int camera_rot_z) {
 
     fRotationYSine = sin((pi_double + pi_double) * (double)sRotationY / 2048.0);
     fRotationYCosine = cos((pi_double + pi_double) * (double)sRotationY / 2048.0);
-
-    int_sine_Z = TrigLUT->Sin(sRotationZ);
-    int_cosine_Z = TrigLUT->Cos(sRotationZ);
-    int_sine_y = TrigLUT->Sin(sRotationY);
-    int_cosine_y = TrigLUT->Cos(sRotationY);
 }
 
 //----- (00436A6D) --------------------------------------------------------

--- a/Engine/Graphics/Camera.h
+++ b/Engine/Graphics/Camera.h
@@ -161,10 +161,6 @@ struct Camera3D {
     float fRotationZCosine = 0;
     float fRotationYSine = 0;
     float fRotationYCosine = 0;
-    int int_sine_Z = 0;
-    int int_cosine_Z = 0;
-    int int_sine_y = 0;
-    int int_cosine_y = 0;
 
     glm::vec3 vCameraPos {};
 

--- a/Engine/Graphics/Camera.h
+++ b/Engine/Graphics/Camera.h
@@ -19,8 +19,6 @@ struct IndoorCameraD3D_Vec3 {
     //----- (004C039C) --------------------------------------------------------
     // void ~IndoorCameraD3D_Vec3() {}
 
-    // void ( ***vdestructor_ptr)(IndoorCameraD3D_Vec3 *, bool);
-
     union {
         struct {
             float x;

--- a/Engine/Graphics/Camera.h
+++ b/Engine/Graphics/Camera.h
@@ -117,8 +117,8 @@ struct Camera3D {
                                unsigned int uOutNumVertices, float z_stuff);
     bool is_face_faced_to_cameraBLV(struct BLVFace *pFace);
     bool is_face_faced_to_cameraODM(struct ODMFace* pFace, struct RenderVertexSoft* a2);
-    bool GetFacetOrientation(char polyType, struct Vec3_float_ *a2,
-                             struct Vec3_float_ *a3, struct Vec3_float_ *a4);
+    bool GetFacetOrientation(char polyType, Vec3_float_ *a2,
+                             Vec3_float_ *a3, Vec3_float_ *a4);
     void ViewTransfrom_OffsetUV(struct RenderVertexSoft *pVertices,
                                 unsigned int uNumVertices,
                                 struct RenderVertexSoft *pOutVertices,

--- a/Engine/Graphics/ClippingFunctions.cpp
+++ b/Engine/Graphics/ClippingFunctions.cpp
@@ -173,7 +173,7 @@ bool stru9::ClipVertsToPortal(struct RenderVertexSoft *pPortalBounding,  // test
 bool stru9::ClipVertsToFrustumPlane(RenderVertexSoft* pInVertices, signed int pInNumVertices,
     RenderVertexSoft* pOutVertices,
     unsigned int* pOutNumVertices,
-    struct Vec3_float_* CamFrustumNormal, float CamDotDistance, char* VertsAdjusted,
+    Vec3_float_* CamFrustumNormal, float CamDotDistance, char* VertsAdjusted,
     int unused) {
     // this cycles through adjust vertice posisiton to supplied frustum plane
     // points are inside frstum plane when point dot product is greater than camera dot distance

--- a/Engine/Graphics/ClippingFunctions.h
+++ b/Engine/Graphics/ClippingFunctions.h
@@ -48,7 +48,7 @@ struct stru9 {
     bool ClipVertsToFrustumPlane(RenderVertexSoft *pInVertices, signed int pInNumVertices,
         RenderVertexSoft *pOutVertices,
         unsigned int* pOutNumVertices,
-        struct Vec3_float_ *CamFrustumNormal, float CamDotDistance, char *VertsAdjusted,
+        Vec3_float_ *CamFrustumNormal, float CamDotDistance, char *VertsAdjusted,
         int unused);
     void AddVertex(struct VertexBuffer *pVertexBuffer,
                    struct RenderVertexSoft *pVertex);

--- a/Engine/Graphics/ClippingFunctions.h
+++ b/Engine/Graphics/ClippingFunctions.h
@@ -59,7 +59,5 @@ struct stru9 {
                              struct RenderVertexSoft *a2, struct stru312 *a3);
     bool DoDecalVertsNeedClipping(struct RenderVertexSoft *a1, struct RenderVertexSoft *a2,
                  struct RenderVertexSoft *a3, struct stru312 *a4);
-
-    void (***vdestructor_ptr)(stru9 *, bool) = nullptr;
 };
 #pragma pack(pop)

--- a/Engine/Graphics/Collisions.h
+++ b/Engine/Graphics/Collisions.h
@@ -13,27 +13,27 @@ struct CollisionState {
      * @param dt                        Time delta, in fixpoint seconds.
      * @return                          True if there is no movement, false otherwise.
      */
-    bool PrepareAndCheckIfStationary(int dt);
+    bool PrepareAndCheckIfStationary(int dt_fp);
 
     // actor is modeled as two spheres, basically "feet" & "head". Collisions are then done for both spheres.
 
     bool check_hi;  // Check the hi sphere collisions. If not set, only the lo sphere is checked.
-    int radius_lo;   // radius of the lo ("feet") sphere.
-    int radius_hi;  // radius of the hi ("head") sphere.
-    Vec3_int_ position_lo; // center of the lo sphere.
-    Vec3_int_ position_hi; // center of the hi sphere.
-    Vec3_int_ new_position_lo; // desired new position for the center of the lo sphere.
-    Vec3_int_ new_position_hi; // desired new position for the center of the hi sphere.
-    Vec3_int_ velocity;  // Movement vector.
-    Vec3_int_ direction;  // Movement direction, basically velocity as a unit vector.
-    int speed = 0;  // Velocity magnitude.
-    int total_move_distance;  // Total move distance, accumulated between collision iterations, starts at 0.
-    int move_distance;  // Desired movement distance for current iteration, minus the distance already covered.
-    int adjusted_move_distance;  // Movement distance for current iteration, adjusted after collision checks.
+    float radius_lo;   // radius of the lo ("feet") sphere.
+    float radius_hi;  // radius of the hi ("head") sphere.
+    Vec3_float_ position_lo; // center of the lo sphere.
+    Vec3_float_ position_hi; // center of the hi sphere.
+    Vec3_float_ new_position_lo; // desired new position for the center of the lo sphere.
+    Vec3_float_ new_position_hi; // desired new position for the center of the hi sphere.
+    Vec3_float_ velocity;  // Movement vector.
+    Vec3_float_ direction;  // Movement direction, basically velocity as a unit vector.
+    float speed = 0;  // Velocity magnitude.
+    float total_move_distance;  // Total move distance, accumulated between collision iterations, starts at 0.
+    float move_distance;  // Desired movement distance for current iteration, minus the distance already covered.
+    float adjusted_move_distance;  // Movement distance for current iteration, adjusted after collision checks.
     unsigned int uSectorID = 0;  // Indoor sector id.
     unsigned int pid;  // PID of the object that we're collided with.
     int ignored_face_id;  // Don't check collisions with this face.
-    BBox_int_ bbox = { 0, 0, 0, 0, 0, 0 };
+    BBox_float_ bbox;
 };
 
 extern CollisionState collision_state;

--- a/Engine/Graphics/DecalBuilder.cpp
+++ b/Engine/Graphics/DecalBuilder.cpp
@@ -312,7 +312,7 @@ bool DecalBuilder::ApplyBloodSplatToTerrain(struct Polygon* terrpoly, Vec3_float
                     WorldMaxZ + bloodsplat_container->pBloodsplats_to_apply[i].radius >
                     bloodsplat_container->pBloodsplats_to_apply[i].z) {
                     // check plane distance
-                    Vec3_float_::NegDot(&triverts->vWorldPosition, terrnorm, tridotdist);
+                    *tridotdist = -Dot(triverts->vWorldPosition, *terrnorm);
 
                     planedist = terrnorm->y * bloodsplat_container->pBloodsplats_to_apply[i].y +
                         terrnorm->z * bloodsplat_container->pBloodsplats_to_apply[i].z +

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -3846,7 +3846,9 @@ void Render::PackScreenshot(unsigned int width, unsigned int height, void *data,
 }
 
 int Render::GetActorsInViewport(int pDepth) {
-    unsigned int
+    // TODO: merge this function with RenderOpenGL::GetActorsInViewport
+
+    int
         v3;  // eax@2 применяется в закле Жар печи для подсчёта кол-ва монстров
              // видимых группе и заполнения массива id видимых монстров
     unsigned int v5;   // eax@2
@@ -3860,6 +3862,9 @@ int Render::GetActorsInViewport(int pDepth) {
     if ((signed int)GetBillboardDrawListSize() > 0) {
         for (a1a = 0; (signed int)a1a < (signed int)v12; ++a1a) {
             v3 = GetParentBillboardID(a1a);
+            if(v3 == -1)
+                continue;
+
             v5 = (unsigned __int16)pBillboardRenderList[v3].object_pid;
             if (PID_TYPE(v5) == OBJECT_Actor) {
                 if (pBillboardRenderList[v3].screen_space_z <= pDepth) {

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -1226,7 +1226,6 @@ Render::Render(
 
     uNumBillboardsToDraw = 0;
 
-    hd_water_tile_id = -1;
     hd_water_current_frame = 0;
 
     this->p2DGraphics = nullptr;

--- a/Engine/Graphics/Direct3D/Render.cpp
+++ b/Engine/Graphics/Direct3D/Render.cpp
@@ -4503,15 +4503,14 @@ void Render::DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) {
         // v81 = (const void
         // *)fixpoint_mul(pSkyPolygon.ptr_38->viewing_angle_from_west_east, v35);
         v36 =
-            (int)(fixpoint_mul(pSkyPolygon.ptr_38->CamVecLeft_Z * 65536.0,
-            (int)v35) +
-                pSkyPolygon.ptr_38->CamVecLeft_Y * 65536.0);
+            fixpoint_mul(static_cast<int>(pSkyPolygon.ptr_38->CamVecLeft_Z * 65536.0), (int)v35) +
+            pSkyPolygon.ptr_38->CamVecLeft_Y * 65536.0;
 
         v81 = v35;
         inter_left = v36;
         // toggle_flag = pSkyPolygon.ptr_38->viewing_angle_from_north_south;
         v81 = (const void *)fixpoint_mul(
-            pSkyPolygon.ptr_38->CamVecFront_Z * 65536.0, (int)v35);
+            static_cast<int>(pSkyPolygon.ptr_38->CamVecFront_Z * 65536.0), (int)v35);
         toggle_flag = (int)v35;
         v75 = (RenderVertexSoft *)((char *)v81 +
             int(pSkyPolygon.ptr_38->CamVecFront_Y * 65536.0));
@@ -4546,9 +4545,10 @@ void Render::DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) {
             toggle_flag = 2 * (signed __int64)y_proj;
             v81 = (const void *)fixpoint_mul(
                 pSkyPolygon.v_18.z,
+                static_cast<int>(
                 (((double)blv_horizon_height_offset - ((double)(2 * (signed __int64)y_proj) -
                     VertexRenderList[j].vWorldViewProjY)) *
-                    (double)fp_over_viewplanedist));
+                    (double)fp_over_viewplanedist)));
             X = (int)((char *)v81 + pSkyPolygon.v_18.x);
         }
         HEXRAYS_LODWORD(v42) = v77 << 16;
@@ -4557,16 +4557,16 @@ void Render::DrawIndoorSky(unsigned int uNumVertices, unsigned int uFaceID) {
         v81 = v37;
 
         // toggle_flag = pSkyPolygon.ptr_38->angle_from_west;
-        v81 = (const void *)fixpoint_mul(pSkyPolygon.ptr_38->CamVecLeft_X * 65536.0f,
+        v81 = (const void *)fixpoint_mul(static_cast<int>(pSkyPolygon.ptr_38->CamVecLeft_X * 65536.0f),
             (int)v37);
-        v43 = inter_left + fixpoint_mul(pSkyPolygon.ptr_38->CamVecLeft_X * 65536.0f, (int)v37);
+        v43 = inter_left + fixpoint_mul(static_cast<int>(pSkyPolygon.ptr_38->CamVecLeft_X * 65536.0f), (int)v37);
         inter_left = (unsigned int)v37;
         y_proj = v43;
 
         // toggle_flag = pSkyPolygon.ptr_38->angle_from_south;
         v75 = (RenderVertexSoft *)((char *)v75 +
             fixpoint_mul(
-                pSkyPolygon.ptr_38->CamVecFront_X * 65536.0f,
+                static_cast<int>(pSkyPolygon.ptr_38->CamVecFront_X * 65536.0f),
                 (int)v37));
         // inter_left = fixpoint_mul(v43, v42 / X);
         v81 = (const void *)fixpoint_mul((int)v75, v42 / X);

--- a/Engine/Graphics/Direct3D/Render.h
+++ b/Engine/Graphics/Direct3D/Render.h
@@ -186,7 +186,7 @@ class Render : public RenderBase {
     virtual void BeginLightmaps2() override;
     virtual void EndLightmaps2() override;
     virtual bool DrawLightmap(struct Lightmap *pLightmap,
-                              struct Vec3_float_ *pColorMult, float z_bias) override;
+                              Vec3_float_ *pColorMult, float z_bias) override;
 
     virtual void BeginDecals() override;
     virtual void EndDecals() override;

--- a/Engine/Graphics/IRender.h
+++ b/Engine/Graphics/IRender.h
@@ -375,7 +375,7 @@ class IRender {
     virtual void BeginLightmaps2() = 0;
     virtual void EndLightmaps2() = 0;
     virtual bool DrawLightmap(struct Lightmap *pLightmap,
-                              struct Vec3_float_ *pColorMult, float z_bias) = 0;
+                              Vec3_float_ *pColorMult, float z_bias) = 0;
 
     virtual void BeginDecals() = 0;
     virtual void EndDecals() = 0;

--- a/Engine/Graphics/IRender.h
+++ b/Engine/Graphics/IRender.h
@@ -208,7 +208,6 @@ class IRender {
         uFogColor = 0;
         memset(pHDWaterBitmapIDs, 0, sizeof(pHDWaterBitmapIDs));
         hd_water_current_frame = 0;
-        hd_water_tile_id = 0;
         pBeforePresentFunction = 0;
         memset(pBillboardRenderListD3D, 0, sizeof(pBillboardRenderListD3D));
         uNumBillboardsToDraw = 0;
@@ -442,7 +441,6 @@ class IRender {
     uint32_t uFogColor;
     unsigned int pHDWaterBitmapIDs[7];
     int hd_water_current_frame;
-    int hd_water_tile_id;
     Texture *hd_water_tile_anim[7];
     void (*pBeforePresentFunction)();
     RenderBillboardD3D pBillboardRenderListD3D[1000];

--- a/Engine/Graphics/ImageFormatConverter.h
+++ b/Engine/Graphics/ImageFormatConverter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 typedef bool (*ImageFormatConverter)(unsigned int num_pixels, const void *src, void *dst);
 
 inline uint32_t R5G6B5_to_A8R8G8B8(uint16_t color16, unsigned char alpha) {

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -1,9 +1,7 @@
-#include "Engine/Log.h"
+#include "ImageLoader.h"
 
 #include <unordered_set>
 #include <string_view>
-
-#include "Engine/ZlibWrapper.h"
 
 #include "Engine/ErrorHandling.h"
 #include "Engine/Graphics/HWLContainer.h"
@@ -12,6 +10,8 @@
 #include "Engine/Graphics/ImageLoader.h"
 #include "Engine/Graphics/PCX.h"
 #include "Engine/Graphics/Sprites.h"
+#include "Engine/Log.h"
+#include "Engine/ZlibWrapper.h"
 
 #include "Platform/Api.h"
 

--- a/Engine/Graphics/ImageLoader.cpp
+++ b/Engine/Graphics/ImageLoader.cpp
@@ -1,5 +1,8 @@
 #include "Engine/Log.h"
 
+#include <unordered_set>
+#include <string_view>
+
 #include "Engine/ZlibWrapper.h"
 
 #include "Engine/ErrorHandling.h"
@@ -12,6 +15,22 @@
 
 #include "Platform/Api.h"
 
+// List of textures that require additional processing for transparent pixels.
+// TODO: move to WoMM config file.
+static const std::unordered_set<std::string_view> transparentTextures = {
+    "hwtrdre",
+    "hwtrdrne",
+    "hwtrdrs",
+    "hwtrdrsw",
+    "hwtrdrxne",
+    "hwtrdrxse",
+    "hwtrdrn",
+    "hwtrdrnw",
+    "hwtrdrse",
+    "hwtrdrw",
+    "hwtrdrxnw",
+    "hwtrdrxsw"
+};
 
 uint32_t *MakeImageSolid(unsigned int width, unsigned int height,
                          uint8_t *pixels, uint8_t *palette) {
@@ -370,30 +389,32 @@ bool Bitmaps_LOD_Loader::Load(unsigned int *width, unsigned int *height,
         size_t w = tex->header.uTextureWidth;
         size_t h = tex->header.uTextureHeight;
 
+        bool haveTransparency = transparentTextures.contains(tex->header.pName);
+
         for (size_t y = 0; y < h; y++) {
             for (size_t x = 0; x < w; x++) {
                 size_t p = y * w + x;
 
                 int pal = tex->paletted_pixels[p];
-                if (pal != 0) {
+                if (haveTransparency && pal == 0) {
+                    ProcessTransparentPixel(tex->paletted_pixels, tex->pPalette24, x, y, w, h, &pixels[p * 4]);
+                } else {
                     pixels[p * 4 + 0] = tex->pPalette24[3 * pal + 2];
                     pixels[p * 4 + 1] = tex->pPalette24[3 * pal + 1];
                     pixels[p * 4 + 2] = tex->pPalette24[3 * pal + 0];
                     pixels[p * 4 + 3] = 255;
-                } else {
-                    ProcessTransparentPixel(tex->paletted_pixels, tex->pPalette24, x, y, w, h, &pixels[p * 4]);
                 }
             }
         }
 
-            *format = IMAGE_FORMAT_A8R8G8B8;
-            *width = tex->header.uTextureWidth;
-            *height = tex->header.uTextureHeight;
-            *out_pixels = pixels;
-            *out_palette = tex->pPalette24;
-            return true;
-        } else {
-            uint16_t* pixels = new uint16_t[num_pixels];
+        *format = IMAGE_FORMAT_A8R8G8B8;
+        *width = tex->header.uTextureWidth;
+        *height = tex->header.uTextureHeight;
+        *out_pixels = pixels;
+        *out_palette = tex->pPalette24;
+        return true;
+    } else {
+        uint16_t* pixels = new uint16_t[num_pixels];
 
         HWLTexture* hwl = render->LoadHwlBitmap(this->resource_name);
         if (hwl) {

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -3350,11 +3350,11 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
         new_party_z = party_z;
         collision_state.position_hi.x = new_party_x;
         collision_state.position_hi.y = new_party_y;
-        collision_state.position_hi.z = (pParty->uPartyHeight - 32) + party_z + 1;
+        collision_state.position_hi.z = (pParty->uPartyHeight - 32.0f) + party_z + 1.0f;
 
         collision_state.position_lo.x = new_party_x;
         collision_state.position_lo.y = new_party_y;
-        collision_state.position_lo.z = collision_state.radius_lo + party_z + 1;
+        collision_state.position_lo.z = collision_state.radius_lo + party_z + 1.0f;
 
         collision_state.velocity.x = party_dx;
         collision_state.velocity.y = party_dy;

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1956,6 +1956,8 @@ void PrepareToLoadBLV(unsigned int bLoading) {
     bNoNPCHiring = false;
     pDest = 1;
     uCurrentlyLoadedLevelType = LEVEL_Indoor;
+    pBLVRenderParams->uPartySectorID = 0;
+    pBLVRenderParams->uPartyEyeSectorID = 0;
 
     engine->SetUnderwater(
         Is_out15odm_underwater());

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -3795,7 +3795,6 @@ void stru154::GetFacePlane(ODMFace *pFace, BSPVertexBuffer *pVertices,
                            Vec3_float_ *pOutNormal, float *pOutDist) {
     Vec3_float_ FirstPairVec;
     Vec3_float_ SecPairVec;
-    Vec3_float_ *CPReturn;
     Vec3_float_ CrossProd;
 
     if (pFace->uNumVertices >= 2) {
@@ -3814,7 +3813,7 @@ void stru154::GetFacePlane(ODMFace *pFace, BSPVertexBuffer *pVertices,
             SecPairVec.z = pVertices->pVertices[pFace->pVertexIDs[i + 2]].z -
                   pVertices->pVertices[pFace->pVertexIDs[i + 1]].z;
 
-            CPReturn = Vec3_float_::Cross(&FirstPairVec, &CrossProd, SecPairVec.x, SecPairVec.y, SecPairVec.z);
+            CrossProd = Cross(FirstPairVec, SecPairVec);
 
             if (CrossProd.x != 0.0 || CrossProd.y != 0.0 || CrossProd.z != 0.0) {
                 CrossProd.Normalize();

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1666,7 +1666,7 @@ void UpdateActors_BLV() {
                                          pActors[actor_id].uActorRadius + pActors[actor_id].uActorHeight - 1;
                 if (collision_state.position_hi.z < collision_state.position_lo.z)
                     collision_state.position_hi.z = pActors[actor_id].vPosition.z +
-                    pActors[actor_id].uActorRadius + 1;
+                        pActors[actor_id].uActorRadius + 1;
                 collision_state.velocity.x = pActors[actor_id].vVelocity.x;
                 collision_state.velocity.y = pActors[actor_id].vVelocity.y;
                 collision_state.velocity.z = pActors[actor_id].vVelocity.z;
@@ -1700,11 +1700,11 @@ void UpdateActors_BLV() {
                         v32 = collision_state.new_position_lo.z - collision_state.radius_lo - 1;
                     } else {
                         v30 = pActors[actor_id].vPosition.x +
-                              fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
+                              collision_state.adjusted_move_distance * collision_state.direction.x;
                         v31 = pActors[actor_id].vPosition.y +
-                              fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+                              collision_state.adjusted_move_distance * collision_state.direction.y;
                         v32 = pActors[actor_id].vPosition.z +
-                              fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+                              collision_state.adjusted_move_distance * collision_state.direction.z;
                     }
                     v33 = GetIndoorFloorZ(Vec3_int_(v30, v31, v32), &collision_state.uSectorID, &uFaceID);
                     if (v33 == -30000)
@@ -1718,11 +1718,11 @@ void UpdateActors_BLV() {
                             v33 >= pActors[actor_id].vPosition.z - 100 || isAboveGround || isFlying) {
                             if (collision_state.adjusted_move_distance < collision_state.move_distance) {
                                 pActors[actor_id].vPosition.x +=
-                                    fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
+                                    collision_state.adjusted_move_distance * collision_state.direction.x;
                                 pActors[actor_id].vPosition.y +=
-                                    fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+                                    collision_state.adjusted_move_distance * collision_state.direction.y;
                                 pActors[actor_id].vPosition.z +=
-                                    fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+                                    collision_state.adjusted_move_distance * collision_state.direction.z;
                                 pActors[actor_id].uSectorID = (short)collision_state.uSectorID;
                                 collision_state.total_move_distance += collision_state.adjusted_move_distance;
                                 v37 = PID_ID(collision_state.pid);
@@ -1864,8 +1864,8 @@ void UpdateActors_BLV() {
                                                       pActors[actor_id].vVelocity.y +
                                                   pIndoor->pFaces[v37].pFacePlane_old.vNormal.z *
                                                       pActors[actor_id].vVelocity.z) >> 16;
-                                        if ((collision_state.speed >> 3) > v61)
-                                            v61 = collision_state.speed >> 3;
+                                        if ((collision_state.speed / 8) > v61)
+                                            v61 = collision_state.speed / 8;
                                         pActors[actor_id].vVelocity.x +=
                                             fixpoint_mul(v61, pIndoor->pFaces[v37].pFacePlane_old.vNormal.x);
                                         pActors[actor_id].vVelocity.y +=
@@ -1899,11 +1899,11 @@ void UpdateActors_BLV() {
                                 v22 = 0;
                                 continue;
                             } else {
-                                pActors[actor_id].vPosition.x = (short)collision_state.new_position_lo.x;
-                                pActors[actor_id].vPosition.y = (short)collision_state.new_position_lo.y;
-                                pActors[actor_id].vPosition.z = (short)collision_state.new_position_lo.z -
-                                    (short)collision_state.radius_lo - 1;
-                                pActors[actor_id].uSectorID = (short)collision_state.uSectorID;
+                                pActors[actor_id].vPosition.x = collision_state.new_position_lo.x;
+                                pActors[actor_id].vPosition.y = collision_state.new_position_lo.y;
+                                pActors[actor_id].vPosition.z = collision_state.new_position_lo.z -
+                                    collision_state.radius_lo - 1;
+                                pActors[actor_id].uSectorID = collision_state.uSectorID;
                                 // goto LABEL_123;
                                 break;
                             }
@@ -3239,38 +3239,38 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 break;
 
             case PARTY_StrafeLeft:
-                party_dx -= fixpoint_mul(TrigLUT->Sin(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier / 2);
-                party_dy += fixpoint_mul(TrigLUT->Cos(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier / 2);
+                party_dx -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
+                party_dy += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
                 party_walking_flag = true;
                 break;
 
             case PARTY_StrafeRight:
-                party_dx += fixpoint_mul(TrigLUT->Sin(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier / 2);
-                party_dy -= fixpoint_mul(TrigLUT->Cos(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier / 2);
+                party_dx += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
+                party_dy -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
                 party_walking_flag = true;
                 break;
 
             case PARTY_WalkForward:
-                party_dx += fixpoint_mul(TrigLUT->Cos(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier);
-                party_dy += fixpoint_mul(TrigLUT->Sin(angle), pParty->uWalkSpeed * fWalkSpeedMultiplier);
+                party_dx += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier));
+                party_dy += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier));
                 party_walking_flag = true;
                 break;
 
             case PARTY_WalkBackward:
-                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier);
-                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier);
+                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
+                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
                 party_walking_flag = true;
                 break;
 
             case PARTY_RunForward:
-                party_dx += fixpoint_mul(TrigLUT->Cos(angle), 2 * pParty->uWalkSpeed * fWalkSpeedMultiplier);
-                party_dy += fixpoint_mul(TrigLUT->Sin(angle), 2 * pParty->uWalkSpeed * fWalkSpeedMultiplier);
+                party_dx += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(2 * pParty->uWalkSpeed * fWalkSpeedMultiplier));
+                party_dy += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(2 * pParty->uWalkSpeed * fWalkSpeedMultiplier));
                 party_running_flag = true;
                 break;
 
             case PARTY_RunBackward:
-                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier);
-                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier);
+                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
+                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
                 party_running_flag = true;
                 break;
 
@@ -3383,9 +3383,9 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
             adjusted_pos.y = collision_state.new_position_lo.y;
             adjusted_pos.z = collision_state.new_position_lo.z - collision_state.radius_lo - 1;
         } else {
-            adjusted_pos.x = new_party_x + fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
-            adjusted_pos.y = new_party_y + fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
-            adjusted_pos.z = new_party_z + fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+            adjusted_pos.x = new_party_x + collision_state.adjusted_move_distance * collision_state.direction.x;
+            adjusted_pos.y = new_party_y + collision_state.adjusted_move_distance * collision_state.direction.y;
+            adjusted_pos.z = new_party_z + collision_state.adjusted_move_distance * collision_state.direction.z;
         }
         int adjusted_floor_z = GetIndoorFloorZ(adjusted_pos + Vec3_int_(0, 0, 40), &collision_state.uSectorID, &uFaceID);
         if (adjusted_floor_z == -30000 || adjusted_floor_z - new_party_z > 128)
@@ -3400,10 +3400,10 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
 
         collision_state.total_move_distance += collision_state.adjusted_move_distance;
 
-        new_party_x += fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
-        new_party_y += fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+        new_party_x += collision_state.adjusted_move_distance * collision_state.direction.x;
+        new_party_y += collision_state.adjusted_move_distance * collision_state.direction.y;
         unsigned long long new_party_z_tmp = new_party_z +
-            fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+            collision_state.adjusted_move_distance * collision_state.direction.z;
 
         if (PID_TYPE(collision_state.pid) == OBJECT_Actor) {
             if (pParty->pPartyBuffs[PARTY_BUFF_INVISIBILITY].Active())
@@ -3438,8 +3438,8 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                     party_dy * pFace->pFacePlane_old.vNormal.y +
                     pParty->uFallSpeed * pFace->pFacePlane_old.vNormal.z) >> 16;
 
-                if ((collision_state.speed >> 3) > speed_dot_normal)
-                    speed_dot_normal = collision_state.speed >> 3;
+                if ((collision_state.speed / 8) > speed_dot_normal)
+                    speed_dot_normal = collision_state.speed / 8;
 
                 party_dx += fixpoint_mul(speed_dot_normal, pFace->pFacePlane_old.vNormal.x);
                 party_dy += fixpoint_mul(speed_dot_normal, pFace->pFacePlane_old.vNormal.y);

--- a/Engine/Graphics/Indoor.cpp
+++ b/Engine/Graphics/Indoor.cpp
@@ -1620,10 +1620,10 @@ void UpdateActors_BLV() {
             if (moveSpeed > 1000)
                 moveSpeed = 1000;
 
-            pActors[actor_id].vVelocity.x = fixpoint_mul(TrigLUT->Cos(pActors[actor_id].uYawAngle), moveSpeed);
-            pActors[actor_id].vVelocity.y = fixpoint_mul(TrigLUT->Sin(pActors[actor_id].uYawAngle), moveSpeed);
+            pActors[actor_id].vVelocity.x = TrigLUT->Cos(pActors[actor_id].uYawAngle) * moveSpeed;
+            pActors[actor_id].vVelocity.y = TrigLUT->Sin(pActors[actor_id].uYawAngle) * moveSpeed;
             if (isFlying)
-                pActors[actor_id].vVelocity.z = fixpoint_mul(TrigLUT->Sin(pActors[actor_id].uPitchAngle), moveSpeed);
+                pActors[actor_id].vVelocity.z = TrigLUT->Sin(pActors[actor_id].uPitchAngle) * moveSpeed;
         } else {  // actor is not moving
             // fixpoint(55000) = 0.83923339843, appears to be velocity decay.
             pActors[actor_id].vVelocity.x = fixpoint_mul(55000, pActors[actor_id].vVelocity.x);
@@ -1827,8 +1827,8 @@ void UpdateActors_BLV() {
                                     v45 = TrigLUT->Atan2(
                                         pActors[actor_id].vPosition.x - pLevelDecorations[v37].vPosition.x,
                                         pActors[actor_id].vPosition.y - pLevelDecorations[v37].vPosition.y);
-                                    pActors[actor_id].vVelocity.x = fixpoint_mul(TrigLUT->Cos(v45), _this);
-                                    pActors[actor_id].vVelocity.y = fixpoint_mul(TrigLUT->Sin(v45), _this);
+                                    pActors[actor_id].vVelocity.x = TrigLUT->Cos(v45) * _this;
+                                    pActors[actor_id].vVelocity.y = TrigLUT->Sin(v45) * _this;
                                     pActors[actor_id].vVelocity.x =
                                         fixpoint_mul(58500, pActors[actor_id].vVelocity.x);
                                     pActors[actor_id].vVelocity.y =
@@ -3239,38 +3239,38 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 break;
 
             case PARTY_StrafeLeft:
-                party_dx -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
-                party_dy += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
+                party_dx -= TrigLUT->Sin(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier / 2;
+                party_dy += TrigLUT->Cos(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier / 2;
                 party_walking_flag = true;
                 break;
 
             case PARTY_StrafeRight:
-                party_dx += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
-                party_dy -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier / 2));
+                party_dy -= TrigLUT->Cos(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier / 2;
+                party_dx += TrigLUT->Sin(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier / 2;
                 party_walking_flag = true;
                 break;
 
             case PARTY_WalkForward:
-                party_dx += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier));
-                party_dy += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fWalkSpeedMultiplier));
+                party_dx += TrigLUT->Cos(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier;
+                party_dy += TrigLUT->Sin(angle) * pParty->uWalkSpeed * fWalkSpeedMultiplier;
                 party_walking_flag = true;
                 break;
 
             case PARTY_WalkBackward:
-                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
-                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
+                party_dx -= TrigLUT->Cos(angle) * pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier;
+                party_dy -= TrigLUT->Sin(angle) * pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier;
                 party_walking_flag = true;
                 break;
 
             case PARTY_RunForward:
-                party_dx += fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(2 * pParty->uWalkSpeed * fWalkSpeedMultiplier));
-                party_dy += fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(2 * pParty->uWalkSpeed * fWalkSpeedMultiplier));
+                party_dx += TrigLUT->Cos(angle) * 2 * pParty->uWalkSpeed * fWalkSpeedMultiplier;
+                party_dy += TrigLUT->Sin(angle) * 2 * pParty->uWalkSpeed * fWalkSpeedMultiplier;
                 party_running_flag = true;
                 break;
 
             case PARTY_RunBackward:
-                party_dx -= fixpoint_mul(TrigLUT->Cos(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
-                party_dy -= fixpoint_mul(TrigLUT->Sin(angle), static_cast<int>(pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier));
+                party_dx -= TrigLUT->Cos(angle) * pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier;
+                party_dy -= TrigLUT->Sin(angle) * pParty->uWalkSpeed * fBackwardWalkSpeedMultiplier;
                 party_running_flag = true;
                 break;
 
@@ -3416,8 +3416,8 @@ void BLV_ProcessPartyActions() {  // could this be combined with odm process act
                 new_party_x - pLevelDecorations[PID_ID(collision_state.pid)].vPosition.x,
                 new_party_y - pLevelDecorations[PID_ID(collision_state.pid)].vPosition.y);
             int len = integer_sqrt(party_dx * party_dx + party_dy * party_dy);
-            party_dx = fixpoint_mul(TrigLUT->Cos(angle), len);
-            party_dy = fixpoint_mul(TrigLUT->Sin(angle), len);
+            party_dx = TrigLUT->Cos(angle) * len;
+            party_dy = TrigLUT->Sin(angle) * len;
         } else if (PID_TYPE(collision_state.pid) == OBJECT_BModel) {
             BLVFace *pFace = &pIndoor->pFaces[PID_ID(collision_state.pid)];
             if (pFace->uPolygonType == POLYGON_Floor) {

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -675,9 +675,11 @@ void BLV_UpdateUserInputAndOther();
 /**
  * @param pos                           Actor's position.
  * @param uSectorID                     Actor's sector id.
- * @param[out] pFaceID                  Id of the closest floor/ceiling face for the provided position.
+ * @param[out] pFaceID                  Id of the closest floor/ceiling face for the provided position, or `-1`
+ *                                      if wrong sector is supplied or actor is out of bounds.
  * @return                              Fixpoint Z coordinate of the floor/ceiling face for the given position.
- *                                      If wrong sector is supplied, `-30000` is returned.
+ *                                      If wrong sector is supplied or actor is out of bounds, `-30000` is
+ *                                      returned.
  */
 int BLV_GetFloorLevel(const Vec3_int_ &pos, unsigned int uSectorID, unsigned int *pFaceID);
 void BLV_UpdateDoors();
@@ -747,10 +749,12 @@ void FindBillboardsLightLevels_BLV();
  * @param pos                           Actor's position.
  * @param[in,out] pSectorID             Actor's cached sector id. If the cached sector id is no longer valid (e.g. an
  *                                      actor has already moved to another sector), then the new sector id is returned
- *                                      in this output parameter.
- * @param[out] pFaceID                  Id of the floor face on which the actor is standing. Not updated if floor face
- *                                      is not found.
- * @return                              Z coordinate for the floor at (X, Y).
+ *                                      in this output parameter. If the actor moves out of level bounds (this happens),
+ *                                      then this parameter is set to 0.
+ * @param[out] pFaceID                  Id of the floor face on which the actor is standing, or `-1` if actor is outside
+ *                                      the level boundaries.
+ * @return                              Z coordinate for the floor at (X, Y), or `-30000` if actor is outside the
+ *                                      level boundaries.
  */
 int GetIndoorFloorZ(const Vec3_int_ &pos, unsigned int *pSectorID, unsigned int *pFaceID);
 

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -190,9 +190,9 @@ struct stru154 {
 
     void GetFacePlaneAndClassify(struct ODMFace *a2,
                                  struct BSPVertexBuffer *a3);
-    void ClassifyPolygon(struct Vec3_float_ *pNormal, float dist);
+    void ClassifyPolygon(Vec3_float_ *pNormal, float dist);
     void GetFacePlane(struct ODMFace *pFace, struct BSPVertexBuffer *pVertices,
-                      struct Vec3_float_ *pOutNormal, float *pOutDist);
+                      Vec3_float_ *pOutNormal, float *pOutDist);
 
     Plane_float_ face_plane {};
     PolygonType polygonType {};
@@ -454,7 +454,7 @@ struct BLVFace {  // 60h
      */
     bool Contains(const Vec3_int_ &pos, int model_idx, int slack = 0, int override_plane = 0) const;
 
-    struct Plane_float_ pFacePlane {};
+    struct Plane_float_ pFacePlane;
     struct Plane_int_ pFacePlane_old;
     PlaneZCalc_int64_ zCalc;
     uint32_t uAttributes;

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -10,6 +10,7 @@
 #include "Engine/Graphics/BSPModel.h"
 #include "Engine/Graphics/IRender.h"
 #include "Engine/Graphics/Camera.h"
+#include "Engine/VectorTypes.h"
 
 struct IndoorLocation;
 
@@ -471,7 +472,7 @@ struct BLVFace {  // 60h
 
     uint16_t uSectorID;
     int16_t uBackSectorID;
-    struct BBox_short_ pBounding {};
+    BBox_short_ pBounding;
     PolygonType uPolygonType;
     uint8_t uNumVertices;
     char field_5E = 0;

--- a/Engine/Graphics/Indoor.h
+++ b/Engine/Graphics/Indoor.h
@@ -194,7 +194,6 @@ struct stru154 {
     void GetFacePlane(struct ODMFace *pFace, struct BSPVertexBuffer *pVertices,
                       struct Vec3_float_ *pOutNormal, float *pOutDist);
 
-    void (***vdestructor_ptr)(stru154 *, bool) = nullptr;
     Plane_float_ face_plane {};
     PolygonType polygonType {};
     char field_15 = 0;

--- a/Engine/Graphics/LightmapBuilder.cpp
+++ b/Engine/Graphics/LightmapBuilder.cpp
@@ -24,7 +24,6 @@ Lightmap::Lightmap() {
     NumVertices = -1;
     for (uint i = 0; i < 64; ++i) pVertices[i].flt_2C = 0.0f;
     this->field_C18 = 0;
-    // this->vdestructor_ptr = &Lightmap_pvdtor;
     uColorMask = 0;
     position_z = 0;
     position_y = 0;

--- a/Engine/Graphics/LightmapBuilder.cpp
+++ b/Engine/Graphics/LightmapBuilder.cpp
@@ -166,8 +166,7 @@ bool LightmapBuilder::StackLight_TerrainFace(StationaryLight *pLight,
         (float)pLight->vPosition.z >= bounding_z2)
         return false;
 
-    Vec3_float_::NegDot(&TerrainVertices->vWorldPosition, pNormal,
-                        light_tile_dist);
+    *light_tile_dist = -Dot(TerrainVertices->vWorldPosition, *pNormal);
     float p_dot = ((float)pLight->vPosition.x * pNormal->x +
                    (float)pLight->vPosition.y * pNormal->y +
                    (float)pLight->vPosition.z * pNormal->z + *light_tile_dist) +

--- a/Engine/Graphics/LightmapBuilder.h
+++ b/Engine/Graphics/LightmapBuilder.h
@@ -13,7 +13,6 @@ struct Lightmap {  // карта света, текстура для налож�
     Lightmap();
     virtual ~Lightmap() {}
 
-    // void ( ***vdestructor_ptr)(Lightmap *, bool);
     signed int NumVertices;
     RenderVertexSoft pVertices[64];
     __int16 position_x;  //позиция источника света
@@ -76,7 +75,6 @@ class LightmapBuilder {
                      unsigned int uNumVertices, struct RenderVertexSoft *a5,
                      struct IndoorCameraD3D_Vec4 *, char uClipFlag);
 
-    // void ( ***vdestructor_ptr)(LightmapBuilder *, bool);
     // std::vector<Lightmap> std__vector_000004;
     // std::vector<Lightmap> std__vector_183808;
     Lightmap StationaryLights[512];      // std__vector_000004

--- a/Engine/Graphics/LightmapBuilder.h
+++ b/Engine/Graphics/LightmapBuilder.h
@@ -45,22 +45,22 @@ class LightmapBuilder {
     // int _45D426_sw(struct Span *a1, struct Edge **a2, unsigned int a3, struct
     // Edge *a4, int a5); bool _45D3C7_sw(struct Polygon *a1);
     bool StackLight_TerrainFace(struct StationaryLight *pLight,
-                                struct Vec3_float_ *pNormal, float *a3,
+                                Vec3_float_ *pNormal, float *a3,
                                 struct RenderVertexSoft *a1,
                                 unsigned int uStripType, int X,
                                 unsigned int *pSlot);
-    bool StackLights_TerrainFace(struct Vec3_float_ *pNormal, float *a3,
+    bool StackLights_TerrainFace(Vec3_float_ *pNormal, float *a3,
                                  struct RenderVertexSoft *a1,
                                  unsigned int uStripType, bool bLightBackfaces);
     bool ApplyLight_ODM(struct StationaryLight *pLight, struct ODMFace *pFace,
                         unsigned int *pSlot, bool bLightBackfaces);
     bool ApplyLights_OutdoorFace(struct ODMFace *pFace);
-    double _45CC0C_light(struct Vec3_float_ a1, float a2, float a3,
-                         struct Vec3_float_ *pNormal, float a5, int uLightType);
+    double _45CC0C_light(Vec3_float_ a1, float a2, float a3,
+                         Vec3_float_ *pNormal, float a5, int uLightType);
     int *_45CBD4(struct RenderVertexSoft *a2, int a3, int *a4, int *a5);
     int _45CB89(struct RenderVertexSoft *a1, int a2);
     int *_45CA88(struct LightsData *a2, struct RenderVertexSoft *a3, int a4,
-                struct Vec3_float_ *pNormal);
+                Vec3_float_ *pNormal);
     bool ApplyLight_BLV(struct StationaryLight *pLight, struct BLVFace *a2,
                         unsigned int *pSlot, bool bLightBackfaces, char *a5);
     bool ApplyLights_IndoorFace(unsigned int uFaceID);

--- a/Engine/Graphics/Lights.h
+++ b/Engine/Graphics/Lights.h
@@ -61,7 +61,6 @@ struct LightsStack_StationaryLight_ {
     bool AddLight(int16_t x, int16_t y, int16_t z, int16_t a5, unsigned char r,
                   unsigned char g, unsigned char b, char uLightType);
 
-    // void ( ***vdestructor_ptr)(LightsStack_StationaryLight_ *, bool);
     StationaryLight pLights[400];
     unsigned int uNumLightsActive;
 
@@ -84,7 +83,6 @@ struct LightsStack_MobileLight_ {
                   int uRadius, uint8_t r, uint8_t g,
                   uint8_t b, char a10);
 
-    // void ( ***vdestructor_ptr)(LightsStack_MobileLight_ *, bool);
     MobileLight pLights[400];
     unsigned int uNumLightsActive;
     Log *log;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -442,10 +442,10 @@ void SkyBillboardStruct::CalcSkyFrustumVec(int x1, int y1, int z1, int x2, int y
 
     // TODO(pskelton): clean up
 
-    float cosz = pCamera3D->fRotationZCosine;  // int_cosine_Z;
-    float cosx = pCamera3D->fRotationYCosine;  // int_cosine_y;
-    float sinz = pCamera3D->fRotationZSine;  // int_sine_Z;
-    float sinx = pCamera3D->fRotationYSine;  // int_sine_y;
+    float cosz = pCamera3D->fRotationZCosine;
+    float cosx = pCamera3D->fRotationYCosine;
+    float sinz = pCamera3D->fRotationZSine;
+    float sinx = pCamera3D->fRotationYSine;
 
     // positions all minus ?
     float v11 = cosz * -pCamera3D->vCameraPos.x + sinz * -pCamera3D->vCameraPos.y;

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1712,9 +1712,9 @@ void RenderOpenGL::SavePCXScreenshot() {
 }
 
 
-// should this be combined / moved out of render
+// TODO: should this be combined / moved out of render
 int RenderOpenGL::GetActorsInViewport(int pDepth) {
-    unsigned int
+    int
         v3;  // eax@2 применяется в закле Жар печи для подсчёта кол-ва монстров
              // видимых группе и заполнения массива id видимых монстров
     unsigned int v5;   // eax@2

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1728,6 +1728,9 @@ int RenderOpenGL::GetActorsInViewport(int pDepth) {
     if ((signed int)render->uNumBillboardsToDraw > 0) {
         for (a1a = 0; (signed int)a1a < (signed int)v12; ++a1a) {
             v3 = render->pBillboardRenderListD3D[a1a].sParentBillboardID;
+            if(v3 == -1)
+                continue; // E.g. spell particle.
+
             v5 = (unsigned __int16)pBillboardRenderList[v3].object_pid;
             if (PID_TYPE(v5) == OBJECT_Actor) {
                 if (pBillboardRenderList[v3].screen_space_z <= pDepth) {

--- a/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -1756,7 +1756,7 @@ void RenderOpenGL::BeginLightmaps() { return; }
 void RenderOpenGL::EndLightmaps() { return; }
 void RenderOpenGL::BeginLightmaps2() { return; }
 void RenderOpenGL::EndLightmaps2() { return; }
-bool RenderOpenGL::DrawLightmap(struct Lightmap *pLightmap, struct Vec3_float_ *pColorMult, float z_bias) {
+bool RenderOpenGL::DrawLightmap(struct Lightmap *pLightmap, Vec3_float_ *pColorMult, float z_bias) {
     return true;
 }
 

--- a/Engine/Graphics/OpenGL/RenderOpenGL.h
+++ b/Engine/Graphics/OpenGL/RenderOpenGL.h
@@ -186,7 +186,7 @@ class RenderOpenGL : public RenderBase {
     virtual void BeginLightmaps2() override;
     virtual void EndLightmaps2() override;
     virtual bool DrawLightmap(struct Lightmap *pLightmap,
-                              struct Vec3_float_ *pColorMult, float z_bias) override;
+                              Vec3_float_ *pColorMult, float z_bias) override;
 
     virtual void BeginDecals() override;
     virtual void EndDecals() override;

--- a/Engine/Graphics/Outdoor.cpp
+++ b/Engine/Graphics/Outdoor.cpp
@@ -2442,7 +2442,7 @@ void ODM_ProcessPartyActions() {
     pParty->sRotationY = _angle_x;
     //-------------------------------------------
     if (pParty->bFlying) {
-        v129 = fixpoint_mul(4, TrigLUT->Cos(OS_GetTime()));
+        v129 = 4 * TrigLUT->Cos(OS_GetTime());
         party_new_Z = v113 + v129;
         if (pModel_) party_new_Z = v113;
         if (pParty->FlyActive())
@@ -2614,9 +2614,9 @@ void ODM_ProcessPartyActions() {
             v129 = TrigLUT->Atan2(
                 _angle_x - pLevelDecorations[(signed int)collision_state.pid >> 3].vPosition.x,
                 _angle_y - pLevelDecorations[(signed int)collision_state.pid >> 3].vPosition.y);
-            v2 = fixpoint_mul(TrigLUT->Cos(v129), integer_sqrt(v2 * v2 + v128 * v128));
-            v122 = fixpoint_mul(TrigLUT->Sin(v129), integer_sqrt(v2 * v2 + v128 * v128));
-            v128 = fixpoint_mul(TrigLUT->Sin(v129), integer_sqrt(v2 * v2 + v128 * v128));
+            v2 = TrigLUT->Cos(v129) * integer_sqrt(v2 * v2 + v128 * v128);
+            v122 = TrigLUT->Sin(v129) * integer_sqrt(v2 * v2 + v128 * v128);
+            v128 = TrigLUT->Sin(v129) * integer_sqrt(v2 * v2 + v128 * v128);
         }
 
         if (PID_TYPE(collision_state.pid) == OBJECT_BModel) {
@@ -3100,12 +3100,12 @@ void UpdateActors_ODM() {
             if (Actor_Speed > 1000) Actor_Speed = 1000;
 
             pActors[Actor_ITR].vVelocity.x =
-                fixpoint_mul(TrigLUT->Cos(pActors[Actor_ITR].uYawAngle), Actor_Speed);
+                TrigLUT->Cos(pActors[Actor_ITR].uYawAngle) * Actor_Speed;
             pActors[Actor_ITR].vVelocity.y =
-                fixpoint_mul(TrigLUT->Sin(pActors[Actor_ITR].uYawAngle), Actor_Speed);
+                TrigLUT->Sin(pActors[Actor_ITR].uYawAngle) * Actor_Speed;
             if (uIsFlying) {
-                pActors[Actor_ITR].vVelocity.z = fixpoint_mul(
-                    TrigLUT->Sin(pActors[Actor_ITR].uPitchAngle), Actor_Speed);
+                pActors[Actor_ITR].vVelocity.z =
+                    TrigLUT->Sin(pActors[Actor_ITR].uPitchAngle) * Actor_Speed;
             }
         } else {
             pActors[Actor_ITR].vVelocity.x =
@@ -3306,9 +3306,9 @@ void UpdateActors_ODM() {
                             pLevelDecorations[v39].vPosition.y);
 
                     pActors[Actor_ITR].vVelocity.x =
-                        fixpoint_mul(TrigLUT->Cos(Angle_To_Decor), Coll_Speed);
+                        TrigLUT->Cos(Angle_To_Decor) * Coll_Speed;
                     pActors[Actor_ITR].vVelocity.y =
-                        fixpoint_mul(TrigLUT->Sin(Angle_To_Decor), Coll_Speed);
+                        TrigLUT->Sin(Angle_To_Decor) * Coll_Speed;
                     break;
                 case OBJECT_BModel:
                     ODMFace * face = &pOutdoor->pBModels[collision_state.pid >> 9]

--- a/Engine/Graphics/Outdoor.cpp
+++ b/Engine/Graphics/Outdoor.cpp
@@ -2551,13 +2551,11 @@ void ODM_ProcessPartyActions() {
             _angle_y = collision_state.new_position_lo.y;
             v40 = collision_state.new_position_lo.z - collision_state.radius_lo - 1;
         } else {
-            _angle_x = pX + fixpoint_mul(collision_state.adjusted_move_distance,
-                                         collision_state.direction.x);
-            _angle_y = pY + fixpoint_mul(collision_state.adjusted_move_distance,
-                                         collision_state.direction.y);
+            _angle_x = pX + collision_state.adjusted_move_distance * collision_state.direction.x;
+            _angle_y = pY + collision_state.adjusted_move_distance * collision_state.direction.y;
             // pModel = (BSPModel *)fixpoint_mul(collision_state.adjusted_move_distance,
             // collision_state.direction.z);
-            v40 = fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z) + party_new_Z;
+            v40 = collision_state.adjusted_move_distance * collision_state.direction.z + party_new_Z;
         }
         v122 = v40;
         ODM_GetFloorLevel(_angle_x, _angle_y, v40, pParty->uPartyHeight, &is_on_water, &bmodel_standing_on_pid, 0);
@@ -2649,8 +2647,8 @@ void ODM_ProcessPartyActions() {
                 v118 = abs(v128 * pODMFace->pFacePlaneOLD.vNormal.y +
                            fall_speed * pODMFace->pFacePlaneOLD.vNormal.z +
                            v2 * pODMFace->pFacePlaneOLD.vNormal.x) >> 16;
-                if ((collision_state.speed >> 3) > v118)
-                    v118 = collision_state.speed >> 3;
+                if ((collision_state.speed / 8) > v118)
+                    v118 = collision_state.speed / 8;
                 v2 += fixpoint_mul(v118, pODMFace->pFacePlaneOLD.vNormal.x);
                 v128 += fixpoint_mul(v118, pODMFace->pFacePlaneOLD.vNormal.y);
                 v54 = 0;
@@ -2676,8 +2674,8 @@ void ODM_ProcessPartyActions() {
                 v118 = abs(v128 * pODMFace->pFacePlaneOLD.vNormal.y +
                            fall_speed * pODMFace->pFacePlaneOLD.vNormal.z +
                            v2 * pODMFace->pFacePlaneOLD.vNormal.x) >> 16;
-                if ((collision_state.speed >> 3) > v118)
-                    v118 = collision_state.speed >> 3;
+                if ((collision_state.speed / 8) > v118)
+                    v118 = collision_state.speed / 8;
                 v2 += fixpoint_mul(v118, pODMFace->pFacePlaneOLD.vNormal.x);
                 v128 += fixpoint_mul(v118, pODMFace->pFacePlaneOLD.vNormal.y);
                 fall_speed += fixpoint_mul(v118, pODMFace->pFacePlaneOLD.vNormal.z);
@@ -3210,7 +3208,7 @@ void UpdateActors_ODM() {
             int v71 = i > 1;
             if (collision_state.adjusted_move_distance < collision_state.move_distance)
                 Slope_High =
-                    fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+                    collision_state.adjusted_move_distance * collision_state.direction.z;
             // v34 = 0;
             int v35 = collision_state.new_position_lo.z - collision_state.radius_lo - 1;
             bool bOnWater = false;
@@ -3238,22 +3236,21 @@ void UpdateActors_ODM() {
                 }
             }
             if (collision_state.adjusted_move_distance >= collision_state.move_distance) {
-                pActors[Actor_ITR].vPosition.x = (short)collision_state.new_position_lo.x;
-                pActors[Actor_ITR].vPosition.y = (short)collision_state.new_position_lo.y;
-                pActors[Actor_ITR].vPosition.z = (short)collision_state.new_position_lo.z -
-                                           (short)collision_state.radius_lo -
-                                           1;
+                pActors[Actor_ITR].vPosition.x = collision_state.new_position_lo.x;
+                pActors[Actor_ITR].vPosition.y = collision_state.new_position_lo.y;
+                pActors[Actor_ITR].vPosition.z = collision_state.new_position_lo.z -
+                                           collision_state.radius_lo - 1;
                 break;
             }
 
             pActors[Actor_ITR].vPosition.x +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
+                collision_state.adjusted_move_distance * collision_state.direction.x;
 
             pActors[Actor_ITR].vPosition.y +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+                collision_state.adjusted_move_distance * collision_state.direction.y;
 
             pActors[Actor_ITR].vPosition.z +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+                collision_state.adjusted_move_distance * collision_state.direction.z;
             collision_state.total_move_distance += collision_state.adjusted_move_distance;
             unsigned int v39 = PID_ID(collision_state.pid);
             int Angle_To_Decor;
@@ -3340,8 +3337,8 @@ void UpdateActors_ODM() {
                                        face->pFacePlaneOLD.vNormal.x *
                                            pActors[Actor_ITR].vVelocity.x) >>
                                    16;
-                            if ((collision_state.speed >> 3) > v72b)
-                                v72b = collision_state.speed >> 3;
+                            if ((collision_state.speed / 8) > v72b)
+                                v72b = collision_state.speed / 8;
 
                             pActors[Actor_ITR].vVelocity.x +=
                                 fixpoint_mul(v72b, face->pFacePlaneOLD.vNormal.x);

--- a/Engine/Graphics/Outdoor.h
+++ b/Engine/Graphics/Outdoor.h
@@ -120,7 +120,7 @@ struct OutdoorLocation {
     std::array<uint16_t, 128 * 128> pCmap; // Unused
     BSPModelList pBModels;
     std::vector<uint16_t> pFaceIDLIST;
-    std::array<unsigned int, 128 * 128> pOMAP;
+    std::array<uint32_t, 128 * 128> pOMAP;
     Texture *sky_texture = nullptr;        // signed int sSky_TextureID;
     Texture *main_tile_texture;  // signed int sMainTile_BitmapID;
     int16_t field_F0;

--- a/Engine/Graphics/PortalFunctions.cpp
+++ b/Engine/Graphics/PortalFunctions.cpp
@@ -409,17 +409,8 @@ bool stru10::CalcPortalFrustumPlane(RenderVertexSoft *pFaceBounding1,
                             RenderVertexSoft *pFaceBounding2,
                             Vec3_float_ *pRayStart,
                             IndoorCameraD3D_Vec4 *pPortalDataFrustum) {
-    Vec3_float_ ray_dir;
-    Vec3_float_ pRay2;
-
-    ray_dir.x = pFaceBounding1->vWorldPosition.x - pRayStart->x;  // get ray for cmera to bounding1
-    ray_dir.y = pFaceBounding1->vWorldPosition.y - pRayStart->y;
-    ray_dir.z = pFaceBounding1->vWorldPosition.z - pRayStart->z;
-    Vec3_float_::Cross(
-        &ray_dir, &pRay2,
-        pFaceBounding2->vWorldPosition.x - pFaceBounding1->vWorldPosition.x,
-        pFaceBounding2->vWorldPosition.y - pFaceBounding1->vWorldPosition.y,
-        pFaceBounding2->vWorldPosition.z - pFaceBounding1->vWorldPosition.z);
+    Vec3_float_ ray_dir = pFaceBounding1->vWorldPosition - *pRayStart; // get ray for cmera to bounding1
+    Vec3_float_ pRay2 = Cross(ray_dir, pFaceBounding2->vWorldPosition - pFaceBounding1->vWorldPosition);
 
     float sqr_mag = pRay2.x * pRay2.x + pRay2.y * pRay2.y + pRay2.z * pRay2.z;
     if (fabsf(sqr_mag) > 1e-6f) {

--- a/Engine/Graphics/PortalFunctions.h
+++ b/Engine/Graphics/PortalFunctions.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Engine/VectorTypes.h>
+
 /*  127 */
 #pragma pack(push, 1)
 struct stru10 {
@@ -11,7 +13,7 @@ struct stru10 {
     bool CalcPortalFrustum(struct RenderVertexSoft *pFaceBounding, struct IndoorCameraD3D_Vec4 *pPortalDataFrustum);
     bool CalcPortalFrustumPlane(struct RenderVertexSoft *pFaceBounding1,
                         struct RenderVertexSoft *pFaceBounding2,
-                        struct Vec3_float_ *pRayStart,
+                        Vec3_float_ *pRayStart,
                         struct IndoorCameraD3D_Vec4 *pPortalDataFrustum);
     bool CalcFaceBounding(struct BLVFace *pFace,
                           struct RenderVertexSoft *pFaceLimits,

--- a/Engine/Graphics/PortalFunctions.h
+++ b/Engine/Graphics/PortalFunctions.h
@@ -21,7 +21,5 @@ struct stru10 {
                            struct RenderVertexSoft pOutVertices[4]);
     void _49CE9E(struct BLVFace *pFace, struct RenderVertexSoft *pVertices,
                  unsigned int uNumVertices, RenderVertexSoft *pOutLimits);
-
-    void (***vdestructor_ptr)(stru10 *, bool) = nullptr;
 };
 #pragma pack(pop)

--- a/Engine/Graphics/Vis.cpp
+++ b/Engine/Graphics/Vis.cpp
@@ -141,11 +141,8 @@ bool Vis::IsPolygonOccludedByBillboard(RenderVertexSoft *vertices,
         if (IsPointInsideD3DBillboard(billboard, x, y)) {
             if (v13 == -1)
                 v13 = i;
-            else if (pBillboardRenderList[billboard->sParentBillboardID]
-                         .screen_space_z <
-                     pBillboardRenderList[render->pBillboardRenderListD3D[v13]
-                                              .sParentBillboardID]
-                         .screen_space_z)
+            else if (pBillboardRenderList[billboard->sParentBillboardID].screen_space_z <
+                     pBillboardRenderList[render->pBillboardRenderListD3D[v13].sParentBillboardID].screen_space_z)
                 v13 = i;
         }
     }
@@ -234,11 +231,9 @@ void Vis::PickBillboards_Mouse(float fPickDepth, float fX, float fY,
                                Vis_SelectionFilter *filter) {
     for (uint i = 0; i < render->uNumBillboardsToDraw; ++i) {
         RenderBillboardD3D *d3d_billboard = &render->pBillboardRenderListD3D[i];
-        if (is_part_of_selection((void *)i, filter) &&
-            IsPointInsideD3DBillboard(d3d_billboard, fX, fY)) {
+        if (is_part_of_selection((void *)i, filter) && IsPointInsideD3DBillboard(d3d_billboard, fX, fY)) {
             if (DoesRayIntersectBillboard(fPickDepth, i)) {
-                RenderBillboard *billboard =
-                    &pBillboardRenderList[d3d_billboard->sParentBillboardID];
+                RenderBillboard *billboard = &pBillboardRenderList[d3d_billboard->sParentBillboardID];
 
                 list->AddObject((void *)d3d_billboard->sParentBillboardID,
                                 VisObjectType_Sprite, billboard->screen_space_z,
@@ -894,8 +889,7 @@ void Vis::PickBillboards_Keyboard(float pick_depth, Vis_SelectionList *list,
 
         if (is_part_of_selection((void *)i, filter)) {
             if (DoesRayIntersectBillboard(pick_depth, i)) {
-                RenderBillboard *billboard =
-                    &pBillboardRenderList[d3d_billboard->sParentBillboardID];
+                RenderBillboard *billboard = &pBillboardRenderList[d3d_billboard->sParentBillboardID];
 
                 list->AddObject((void *)d3d_billboard->sParentBillboardID,
                                 VisObjectType_Sprite, billboard->screen_space_z,

--- a/Engine/Graphics/Vis.h
+++ b/Engine/Graphics/Vis.h
@@ -68,7 +68,6 @@ struct Vis_SelectionList {
         uNumPointers++;
     }
 
-    void (***vdestructor_ptr)(Vis_SelectionList *, bool) = nullptr;
     Vis_ObjectInfo object_pool[512] {};
     Vis_ObjectInfo* object_pointers[512] {};
     unsigned int uNumPointers;
@@ -148,7 +147,6 @@ class Vis {
     void SortByScreenSpaceY(struct RenderVertexSoft *pArray, int start,
                             int end);
 
-    // void ( ***vdestructor_ptr)(Vis *, bool);
     Vis_SelectionList default_list;
     RenderVertexSoft stru_200C;
     RenderVertexSoft stru_203C;

--- a/Engine/LOD.cpp
+++ b/Engine/LOD.cpp
@@ -1057,11 +1057,6 @@ int LODFile_IconsBitmaps::ReloadTexture(Texture_MM7 *pDst,
 int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
                                              const std::string &pContainer,
                                              enum TEXTURE_TYPE eTextureType) {
-    //int result;        // esi@14
-    unsigned int v14;  // eax@21
-    // size_t v22;        // ST2C_4@29
-    // const void *v23;   // ecx@29
-
     size_t data_size = 0;
     FILE *pFile = FindContainer(pContainer, &data_size);
     if (pFile == nullptr) {
@@ -1085,23 +1080,6 @@ int LODFile_IconsBitmaps::LoadTextureFromLOD(Texture_MM7 *pOutTex,
             ptr_011BB4 = new char[1000];
             memset(ptr_011BB4, 0, 1000);
         }
-        if (!iequals(pContainer, "wtrdr")) {
-            if (iequals(pContainer, "WtrTyl"))
-                render->hd_water_tile_id = uNumLoadedFiles;
-            v14 = uNumLoadedFiles;
-            // result = render->LoadTexture(pContainer, pOutTex->palette_id1,
-            // (void **)&pHardwareSurfaces[v14], (void
-            // **)&pHardwareTextures[v14]);
-            //result = 1;
-        } else {
-            char *temp_container;
-            temp_container = (char *)malloc(pContainer.size() + 2);
-            *temp_container = 104;  // 'h'
-            strcpy(temp_container + 1, pContainer.c_str());
-            //result = 1;
-            free((void *)temp_container);
-        }
-        //return result;
     }
 
     // ICONS

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -5282,7 +5282,7 @@ void area_of_effect__damage_evaluate() {
 
                         // check line of sight
                         if (Check_LineOfSight(pActors[target_id].vPosition.x, pActors[target_id].vPosition.y, pActors[target_id].vPosition.z + 50, attacker_coord)) {
-                            Vec3_int_::Normalize(&xdiff, &ydiff, &zvec);
+                            normalize_to_fixpoint(&xdiff, &ydiff, &zvec);
                             AttackerInfo.vec_4B4[attack_index].x = xdiff;
                             AttackerInfo.vec_4B4[attack_index].y = ydiff;
                             AttackerInfo.vec_4B4[attack_index].z = zvec;
@@ -5349,7 +5349,7 @@ void area_of_effect__damage_evaluate() {
                                            pActors[actorID].vPosition.y,
                                            pActors[actorID].vPosition.z + 50,
                                            attacker_coord)) {
-                                Vec3_int_::Normalize(&xdiff, &ydiff, &zvec);
+                                normalize_to_fixpoint(&xdiff, &ydiff, &zvec);
                                 AttackerInfo.vec_4B4[attack_index].x = xdiff;
                                 AttackerInfo.vec_4B4[attack_index].y = ydiff;
                                 AttackerInfo.vec_4B4[attack_index].z = zvec;

--- a/Engine/Objects/Actor.cpp
+++ b/Engine/Objects/Actor.cpp
@@ -1065,9 +1065,9 @@ void Actor::GetDirectionInfo(unsigned int uObj1ID, unsigned int uObj2ID,
         pOut->uDistance = (uint)v33;
         pOut->uDistanceXZ = (uint)sqrt(outy2 + outx2);
         pOut->uYawAngle =
-            TrigLUT->Atan2((signed __int64)v31, (signed __int64)v32);
+            TrigLUT->Atan2(v31, v32);
         pOut->uPitchAngle =
-            TrigLUT->Atan2(pOut->uDistanceXZ, (signed __int64)a4a);
+            TrigLUT->Atan2(pOut->uDistanceXZ, a4a);
     }
 }
 
@@ -2049,8 +2049,8 @@ void Actor::AI_Pursue1(unsigned int uActorID, unsigned int a2, signed int arg0,
         v18 = 16;
 
     v7->uYawAngle = TrigLUT->Atan2(
-        pParty->vPosition.x + (int)fixpoint_mul(TrigLUT->Cos(v18 + TrigLUT->uIntegerPi + v10->uYawAngle), v10->uDistanceXZ) - v7->vPosition.x,
-        pParty->vPosition.y + (int)fixpoint_mul(TrigLUT->Sin(v18 + TrigLUT->uIntegerPi + v10->uYawAngle), v10->uDistanceXZ) - v7->vPosition.y);
+        pParty->vPosition.x + TrigLUT->Cos(v18 + TrigLUT->uIntegerPi + v10->uYawAngle) * v10->uDistanceXZ - v7->vPosition.x,
+        pParty->vPosition.y + TrigLUT->Sin(v18 + TrigLUT->uIntegerPi + v10->uYawAngle) * v10->uDistanceXZ - v7->vPosition.y);
     if (uActionLength)
         v7->uCurrentActionLength = uActionLength;
     else
@@ -2625,8 +2625,8 @@ void Actor::SummonMinion(int summonerId) {
     }
     v27 = uCurrentlyLoadedLevelType == LEVEL_Outdoor ? 128 : 64;
     v13 = rand() % 2048;
-    v15 = fixpoint_mul(TrigLUT->Cos(v13), v27) + this->vPosition.x;
-    v17 = fixpoint_mul(TrigLUT->Sin(v13), v27) + this->vPosition.y;
+    v15 = TrigLUT->Cos(v13) * v27 + this->vPosition.x;
+    v17 = TrigLUT->Sin(v13) * v27 + this->vPosition.y;
 
     if (uCurrentlyLoadedLevelType == LEVEL_Indoor) {
         result = pIndoor->GetSector(v15, v17, this->vPosition.z);
@@ -4916,11 +4916,9 @@ int Spawn_Light_Elemental(int spell_power, int caster_skill_level, int duration_
         pActors[uActorIndex].uMovementSpeed =
             pMonsterList->pMonsters[uMonsterID].uMovementSpeed;
         v10 = rand() % 2048;
-        pActors[uActorIndex].vInitialPosition.x =
-            pParty->vPosition.x + fixpoint_mul(TrigLUT->Cos(v10), v19);
+        pActors[uActorIndex].vInitialPosition.x = pParty->vPosition.x + TrigLUT->Cos(v10) * v19;
         pActors[uActorIndex].vPosition.x = pActors[uActorIndex].vInitialPosition.x;
-        pActors[uActorIndex].vInitialPosition.y =
-            pParty->vPosition.y + fixpoint_mul(TrigLUT->Sin(v10), v19);
+        pActors[uActorIndex].vInitialPosition.y = pParty->vPosition.y + TrigLUT->Sin(v10) * v19;
         pActors[uActorIndex].vPosition.y = pActors[uActorIndex].vInitialPosition.y;
         pActors[uActorIndex].vInitialPosition.z = pParty->vPosition.z;
         pActors[uActorIndex].vPosition.z = pActors[uActorIndex].vInitialPosition.z;
@@ -5189,9 +5187,9 @@ void SpawnEncounter(MapInfo *pMapInfo, SpawnPointMM7 *spawn, int a3, int a4, int
         pMonster->PrepareSprites(0);
         pMonster->pMonsterInfo.uHostilityType = MonsterInfo::Hostility_Friendly;
         v32 = rand();
-        a3 = fixpoint_mul(TrigLUT->Cos(v32 % 2048), v52);
+        a3 = TrigLUT->Cos(v32 % 2048) * v52;
         pPosX = a3 + spawn->vPosition.x;
-        a3 = fixpoint_mul(TrigLUT->Sin(v32 % 2048), v52);
+        a3 = TrigLUT->Sin(v32 % 2048) * v52;
         a4 = a3 + spawn->vPosition.y;
         a3 = spawn->vPosition.z;
         if (uCurrentlyLoadedLevelType == LEVEL_Outdoor) {

--- a/Engine/Objects/Player.cpp
+++ b/Engine/Objects/Player.cpp
@@ -7742,11 +7742,8 @@ void Player::_42ECB5_PlayerAttacksActor() {
     } else if (target_type == OBJECT_Actor && actor_distance <= 407.2) {
         melee_attack = true;
 
-        Vec3_int_ a3;
-        a3.x = actor->vPosition.x - pParty->vPosition.x;
-        a3.y = actor->vPosition.y - pParty->vPosition.y;
-        a3.z = actor->vPosition.z - pParty->vPosition.z;
-        Vec3_int_::Normalize(&a3.x, &a3.y, &a3.z);
+        Vec3_int_ a3 = actor->vPosition - pParty->vPosition;
+        normalize_to_fixpoint(&a3.x, &a3.y, &a3.z);
 
         Actor::DamageMonsterFromParty(PID(OBJECT_Player, uActiveCharacter - 1),
                                       target_id, &a3);

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -472,20 +472,20 @@ void SpriteObject::UpdateObject_fn0_BLV(unsigned int uLayingItemID) {
     SpriteObject *pSpriteObject = &pSpriteObjects[uLayingItemID];
     ObjectDesc *pObject = &pObjectList->pObjects[pSpriteObject->uObjectDescID];
 
-    pSpriteObject->uSectorID = pIndoor->GetSector(pSpriteObject->vPosition);
-
-    unsigned int uFaceID;
-
-    int floor_lvl = BLV_GetFloorLevel(pSpriteObject->vPosition, pSpriteObject->uSectorID, &uFaceID);
-
-    // object out of bounds
-    if (abs(pSpriteObject->vPosition.x) > 32767 ||
-        abs(pSpriteObject->vPosition.y) > 32767 ||
-        abs(pSpriteObject->vPosition.z) > 20000 ||
-        floor_lvl <= -30000 && (pSpriteObject->uSectorID == 0)) {
+    // Break early if we're out of bounds.
+    if (abs(pSpriteObject->vPosition.x) > 32767 || abs(pSpriteObject->vPosition.y) > 32767 || abs(pSpriteObject->vPosition.z) > 20000) {
         SpriteObject::OnInteraction(uLayingItemID);
         return;
     }
+
+    unsigned int uFaceID;
+    unsigned int uSectorID = pSpriteObject->uSectorID; // TODO: this should go straight into GetIndoorFloorZ as a pointer.
+    int floor_lvl = GetIndoorFloorZ(pSpriteObject->vPosition, &uSectorID, &uFaceID);
+    if (floor_lvl <= -30000) {
+        SpriteObject::OnInteraction(uLayingItemID);
+        return;
+    }
+    pSpriteObject->uSectorID = uSectorID;
 
     int v15;               // ebx@46
     int v17;                      // eax@50

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -873,8 +873,8 @@ uint8_t SpriteObject::GetParticleTrailColorB() {
 void SpriteObject::OnInteraction(unsigned int uLayingItemID) {
     pSpriteObjects[uLayingItemID].uObjectDescID = 0;
     if (pParty->bTurnBasedModeOn) {
-        if (pSpriteObjects[uLayingItemID].uAttributes & 4) {
-            pSpriteObjects[uLayingItemID].uAttributes &= 0xFFFB;  // ~0x00000004
+        if (pSpriteObjects[uLayingItemID].uAttributes & 0x4) {
+            pSpriteObjects[uLayingItemID].uAttributes &= ~0x4;
             --pTurnEngine->pending_actions;
         }
     }

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -115,13 +115,9 @@ int SpriteObject::Create(int yaw, int pitch, int speed, int which_char) {
 
     // calcualte angle velocity - could use rotate func here as above
     if (speed) {
-        long long v13 =
-            fixpoint_mul(TrigLUT->Cos(yaw), TrigLUT->Cos(pitch));
-        long long a5a =
-            fixpoint_mul(TrigLUT->Sin(yaw), TrigLUT->Cos(pitch));
-        vVelocity.x = fixpoint_mul(v13, speed);
-        vVelocity.y = fixpoint_mul(a5a, speed);
-        vVelocity.z = fixpoint_mul(TrigLUT->Sin(pitch), speed);
+        vVelocity.x = TrigLUT->Cos(yaw) * TrigLUT->Cos(pitch) * speed;
+        vVelocity.y = TrigLUT->Sin(yaw) * TrigLUT->Cos(pitch) * speed;
+        vVelocity.z = TrigLUT->Sin(pitch) * speed;
     }
 
     // copy sprite object into slot
@@ -459,10 +455,8 @@ LABEL_13:
         v38 = TrigLUT->Atan2(
             pSpriteObjects[uLayingItemID].vPosition.x - pLevelDecorations[PID_ID(collision_state.pid)].vPosition.x,
             pSpriteObjects[uLayingItemID].vPosition.y - pLevelDecorations[PID_ID(collision_state.pid)].vPosition.y);
-        pSpriteObjects[uLayingItemID].vVelocity.x =
-            fixpoint_mul(TrigLUT->Cos(v38), v57);
-        pSpriteObjects[uLayingItemID].vVelocity.y = fixpoint_mul(
-            TrigLUT->Sin(v38 - TrigLUT->uIntegerHalfPi), v57);
+        pSpriteObjects[uLayingItemID].vVelocity.x = TrigLUT->Cos(v38) * v57;
+        pSpriteObjects[uLayingItemID].vVelocity.y = TrigLUT->Sin(v38 - TrigLUT->uIntegerHalfPi) * v57;
         goto LABEL_74;
     }
 }
@@ -629,10 +623,8 @@ LABEL_25:
                                            pLevelDecorations[v15].vPosition.x,
                                        pSpriteObject->vPosition.y -
                                            pLevelDecorations[v15].vPosition.y);
-                pSpriteObject->vVelocity.x =
-                    fixpoint_mul(TrigLUT->Cos(v23), v40);
-                pSpriteObject->vVelocity.y =
-                    fixpoint_mul(TrigLUT->Sin(v23), v40);
+                pSpriteObject->vVelocity.x = TrigLUT->Cos(v23) * v40;
+                pSpriteObject->vVelocity.y = TrigLUT->Sin(v23) * v40;
             }
             if (PID_TYPE(collision_state.pid) == OBJECT_BModel) {
                 collision_state.ignored_face_id = PID_ID(collision_state.pid);

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -445,7 +445,7 @@ LABEL_13:
                         EventProcessor(face->sCogTriggeredID, 0, 1);
                 }
             }
-        LABEL_74:
+        //LABEL_74:
             pSpriteObjects[uLayingItemID].vVelocity.x = fixpoint_mul(58500, pSpriteObjects[uLayingItemID].vVelocity.x);
             pSpriteObjects[uLayingItemID].vVelocity.y = fixpoint_mul(58500, pSpriteObjects[uLayingItemID].vVelocity.y);
             pSpriteObjects[uLayingItemID].vVelocity.z = fixpoint_mul(58500, pSpriteObjects[uLayingItemID].vVelocity.z);
@@ -457,7 +457,7 @@ LABEL_13:
             pSpriteObjects[uLayingItemID].vPosition.y - pLevelDecorations[PID_ID(collision_state.pid)].vPosition.y);
         pSpriteObjects[uLayingItemID].vVelocity.x = TrigLUT->Cos(v38) * v57;
         pSpriteObjects[uLayingItemID].vVelocity.y = TrigLUT->Sin(v38 - TrigLUT->uIntegerHalfPi) * v57;
-        goto LABEL_74;
+        //goto LABEL_74; // This goto results in an infinite loop, commented out.
     }
 }
 

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -391,14 +391,14 @@ LABEL_13:
             }
             // v60 = ((unsigned __int64)(collision_state.adjusted_move_distance * (signed
             // __int64)collision_state.direction.x) >> 16);
-            pSpriteObjects[uLayingItemID].vPosition.x += fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
+            pSpriteObjects[uLayingItemID].vPosition.x += collision_state.adjusted_move_distance * collision_state.direction.x;
             // v60 = ((unsigned __int64)(collision_state.adjusted_move_distance * (signed
             // __int64)collision_state.direction.y) >> 16);
-            pSpriteObjects[uLayingItemID].vPosition.y += fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+            pSpriteObjects[uLayingItemID].vPosition.y += collision_state.adjusted_move_distance * collision_state.direction.y;
             // v60 = ((unsigned __int64)(collision_state.adjusted_move_distance * (signed
             // __int64)collision_state.direction.z) >> 16);
             v28 = (short)collision_state.uSectorID;
-            pSpriteObjects[uLayingItemID].vPosition.z += fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+            pSpriteObjects[uLayingItemID].vPosition.z += collision_state.adjusted_move_distance * collision_state.direction.z;
             v29 = pSpriteObjects[uLayingItemID].vPosition.z;
             pSpriteObjects[uLayingItemID].uSectorID = v28;
             collision_state.total_move_distance += collision_state.adjusted_move_distance;
@@ -429,8 +429,8 @@ LABEL_13:
                               face->pFacePlaneOLD.vNormal.y * pSpriteObjects[uLayingItemID].vVelocity.y +
                               face->pFacePlaneOLD.vNormal.z * pSpriteObjects[uLayingItemID].vVelocity.z) >>
                           16;
-                    if ((collision_state.speed >> 3) > v56)
-                        v56 = collision_state.speed >> 3;
+                    if ((collision_state.speed / 8) > v56)
+                        v56 = collision_state.speed / 8;
                     // v57 = fixpoint_mul(v56, face->pFacePlane.vNormal.x);
                     // v58 = fixpoint_mul(v56, face->pFacePlane.vNormal.y);
                     v60 = fixpoint_mul(v56, face->pFacePlaneOLD.vNormal.z);
@@ -597,19 +597,19 @@ LABEL_25:
             // __int64)collision_state.direction.x) >> 16;
 
             pSpriteObject->vPosition.x +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.x);
+                collision_state.adjusted_move_distance * collision_state.direction.x;
 
             // v40 = (unsigned __int64)(collision_state.adjusted_move_distance * (signed
             // __int64)collision_state.direction.y) >> 16;
 
             pSpriteObject->vPosition.y +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.y);
+                collision_state.adjusted_move_distance * collision_state.direction.y;
 
             // v40 = (unsigned __int64)(collision_state.adjusted_move_distance * (signed
             // __int64)collision_state.direction.z) >> 16;
 
             pSpriteObject->vPosition.z +=
-                fixpoint_mul(collision_state.adjusted_move_distance, collision_state.direction.z);
+                collision_state.adjusted_move_distance * collision_state.direction.z;
 
             pSpriteObject->uSectorID = collision_state.uSectorID;
             collision_state.total_move_distance += collision_state.adjusted_move_distance;
@@ -644,8 +644,8 @@ LABEL_25:
                               pIndoor->pFaces[v15].pFacePlane_old.vNormal.z *
                                   pSpriteObject->vVelocity.z) >>
                           16;
-                    if ((collision_state.speed >> 3) > floor_lvl)
-                        floor_lvl = collision_state.speed >> 3;
+                    if ((collision_state.speed / 8) > floor_lvl)
+                        floor_lvl = collision_state.speed / 8;
                     pSpriteObject->vVelocity.x +=
                         2 *
                         fixpoint_mul(

--- a/Engine/Objects/SpriteObject.cpp
+++ b/Engine/Objects/SpriteObject.cpp
@@ -1712,7 +1712,7 @@ void Apply_Spell_Sprite_Damage(unsigned int uLayingItemID, int a2) {
         layingitem_vel_50FDFC.y = pSpriteObjects[uLayingItemID].vVelocity.y;
         layingitem_vel_50FDFC.z = pSpriteObjects[uLayingItemID].vVelocity.z;
 
-        Vec3_int_::Normalize(&layingitem_vel_50FDFC.x, &layingitem_vel_50FDFC.y,
+        normalize_to_fixpoint(&layingitem_vel_50FDFC.x, &layingitem_vel_50FDFC.y,
                              &layingitem_vel_50FDFC.z);
         DamagePlayerFromMonster(PID(OBJECT_Item, uLayingItemID),
                                 pSpriteObjects[uLayingItemID].field_61,
@@ -1722,7 +1722,7 @@ void Apply_Spell_Sprite_Damage(unsigned int uLayingItemID, int a2) {
         layingitem_vel_50FDFC.y = pSpriteObjects[uLayingItemID].vVelocity.y;
         layingitem_vel_50FDFC.z = pSpriteObjects[uLayingItemID].vVelocity.z;
 
-        Vec3_int_::Normalize(&layingitem_vel_50FDFC.x, &layingitem_vel_50FDFC.y,
+        normalize_to_fixpoint(&layingitem_vel_50FDFC.x, &layingitem_vel_50FDFC.y,
                              &layingitem_vel_50FDFC.z);
         switch (PID_TYPE(pSpriteObjects[uLayingItemID].spell_caster_pid)) {
             case OBJECT_Actor:

--- a/Engine/Objects/SpriteObject.h
+++ b/Engine/Objects/SpriteObject.h
@@ -38,7 +38,7 @@ struct SpriteObject {
 
     SPRITE_OBJECT_TYPE uType;
     // unsigned __int16 uType;
-    unsigned __int16 uObjectDescID = 0;
+    unsigned __int16 uObjectDescID = 0; // Zero means free slot, can reuse.
     Vec3_int_ vPosition;
     Vec3_short_ vVelocity;
     unsigned __int16 uFacing;

--- a/Engine/OurMath.h
+++ b/Engine/OurMath.h
@@ -2,8 +2,9 @@
 
 #include <cassert>
 #include <cmath>
-#include <limits>
 #include <cstdint>
+#include <array>
+#include <limits>
 
 #include "Engine/MM7.h"
 
@@ -107,26 +108,40 @@ inline bool FuzzyIsNull(double value) {
 // };
 // #pragma pack(pop)
 
-/*  186 */
-#pragma pack(push, 1)
-struct TrigTableLookup {
+/**
+ * Lookup table for trigonometric functions.
+ */
+class TrigTableLookup {
+ public:
+    static const int uIntegerPi = 1024;
+    static const int uIntegerHalfPi = 512;
+    static const int uIntegerDoublePi = 2048;
+    static const int uDoublePiMask = 2047;
+    static const int uPiMask = 1023;
+    static const int uHalfPiMask = 511;
+
     TrigTableLookup();
 
-    int Cos(int angle);
-    unsigned int Atan2(int x, int y);
-    int Sin(int angle);
+    /**
+     * @param angle                     Angle in 1/2048ths of a full circle.
+     * @return                          Cosine of the provided angle.
+     */
+    float Cos(int angle) const;
 
-    int pTanTable[520];
-    int pCosTable[520];
-    int pInvCosTable[520];
-    static const unsigned int uIntegerPi = 1024;
-    static const unsigned int uIntegerHalfPi = 512;
-    static const unsigned int uIntegerDoublePi = 2048;
-    static const unsigned int uDoublePiMask = 2047;
-    static const unsigned int uPiMask = 1023;
-    static const unsigned int uHalfPiMask = 511;
+    /**
+     * @param angle                     Angle in 1/2048ths of a full circle.
+     * @return                          Sine of the provided angle.
+     */
+    float Sin(int angle) const;
+
+    /**
+     * @return                          Angle in 1/2048ths of a full circle. Actual result is in range [0, 2047].
+     */
+    int Atan2(int x, int y) const;
+
+ private:
+    std::array<float, uIntegerHalfPi + 1> pCosTable;
 };
-#pragma pack(pop)
 
 template <typename FloatType>
 inline int bankersRounding(const FloatType &value) {
@@ -158,4 +173,4 @@ inline int bankersRounding<double>(const double &inValue) {
     return c.l;
 }
 
-extern struct TrigTableLookup *TrigLUT;
+extern TrigTableLookup *TrigLUT;

--- a/Engine/OurMath.h
+++ b/Engine/OurMath.h
@@ -10,11 +10,13 @@
 #define pi_double 3.14159265358979323846
 
 __int64 fixpoint_mul(int, int);
-// __int64 fixpoint_dot(int x1, int x2, int y1, int y2, int z1, int z2);
 __int64 fixpoint_div(int, int);
-// __int64 fixpoint_sub_unknown(int, int);
-// int fixpoint_from_float(float value);
-// int fixpoint_from_int(int lhv, int rhv);
+
+// These shouldn't compile:
+void fixpoint_mul(float, float) = delete;
+void fixpoint_div(float, float) = delete;
+void fixpoint_mul(double, double) = delete;
+void fixpoint_div(double, double) = delete;
 
 /**
  * @param value                         Fixed-point value.

--- a/Engine/OurMath.h
+++ b/Engine/OurMath.h
@@ -40,6 +40,13 @@ inline void normalize_to_fixpoint(int *x, int *y, int *z) {
     *z *= mult;
 }
 
+inline bool FuzzyIsNull(float value) {
+    return std::abs(value) < 0.00001f;
+}
+
+inline bool FuzzyIsNull(double value) {
+    return std::abs(value) < 0.000000000001;
+}
 
 // #pragma pack(push, 1)
 // struct fixed {  // fixed-point decimal

--- a/Engine/OurMath.h
+++ b/Engine/OurMath.h
@@ -28,6 +28,19 @@ int integer_sqrt(int val);
 int GetDiceResult(unsigned int uNumDice, unsigned int uDiceSides);  // idb
 inline int round_to_int(float x) { return (int)floor(x + 0.5f); }
 
+/**
+ * Takes a non-fixpoint vector and normalizes it, resulting in a fixpoint vector.
+ */
+inline void normalize_to_fixpoint(int *x, int *y, int *z) {
+    extern int integer_sqrt(int val);
+    int denom = *y * *y + *z * *z + *x * *x;
+    int mult = 65536 / (integer_sqrt(denom) | 1);
+    *x *= mult;
+    *y *= mult;
+    *z *= mult;
+}
+
+
 // #pragma pack(push, 1)
 // struct fixed {  // fixed-point decimal
 //    inline fixed() : _internal(0) {}

--- a/Engine/Party.h
+++ b/Engine/Party.h
@@ -270,13 +270,13 @@ struct Party {
     bool IsPartyGood();
     size_t ImmolationAffectedActors(int *affected, size_t affectedArrSize, size_t effectRange);
     int field_0_set25_unused;
-    unsigned int uPartyHeight;
-    unsigned int uDefaultPartyHeight;
+    int uPartyHeight;
+    int uDefaultPartyHeight;
     int sEyelevel;
-    unsigned int uDefaultEyelevel;
+    int uDefaultEyelevel;
     int radius; // party radius, 37 by default.
     int y_rotation_granularity;
-    unsigned int uWalkSpeed;
+    int uWalkSpeed;
     int y_rotation_speed;  // deg/s
     int jump_strength; // jump strength, higher value => higher jumps, default 5.
     int field_28_set0_unused;

--- a/Engine/Serialization/LegacyImages.h
+++ b/Engine/Serialization/LegacyImages.h
@@ -73,7 +73,7 @@ struct BLVFace_MM7 {  // 60h
     uint16_t uBitmapID;
     uint16_t uSectorID;
     int16_t uBackSectorID;
-    struct BBox_short_ pBounding;
+    BBox_short_ pBounding;
     uint8_t uPolygonType;
     uint8_t uNumVertices;
     char field_5E;

--- a/Engine/Spells/CastSpellInfo.cpp
+++ b/Engine/Spells/CastSpellInfo.cpp
@@ -258,9 +258,9 @@ void CastSpellInfoHelpers::CastSpell() {
                 pSpellSprite.uSoundID = pCastSpell->sound_id;
                 pPlayer = &pParty->pPlayers[pCastSpell->uPlayerID];
                 memcpy(&pSpellSprite.containing_item, &pPlayer->pInventoryItemList[pPlayer->pEquipment.uBow - 1], sizeof(pSpellSprite.containing_item));
-                pSpellSprite.uAttributes = 256;
+                pSpellSprite.uAttributes = 0x100;
                 if (pParty->bTurnBasedModeOn) {
-                    pSpellSprite.uAttributes = 260;
+                    pSpellSprite.uAttributes = 0x104;
                 }
                 for (int i = 0; i < amount; ++i) {
                     if (i)

--- a/Engine/VectorTypes.cpp
+++ b/Engine/VectorTypes.cpp
@@ -18,10 +18,3 @@ uint32_t int_get_vector_length(int32_t x, int32_t y, int32_t z) { // approx dist
 
     return x + (11 * y >> 5) + (z >> 2);
 }
-
-void Vec3_float_::Normalize() {
-    float denom = (1.0 / sqrt(this->x * this->x + this->y * this->y + this->z * this->z));
-    this->x = denom * this->x;
-    this->y = denom * this->y;
-    this->z = denom * this->z;
-}

--- a/Engine/VectorTypes.h
+++ b/Engine/VectorTypes.h
@@ -191,41 +191,25 @@ struct Plane_int_ {
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-struct BBox_short_ {
-    int16_t x1 = 0;
-    int16_t x2 = 0;
-    int16_t y1 = 0;
-    int16_t y2 = 0;
-    int16_t z1 = 0;
-    int16_t z2 = 0;
+template<class T>
+struct BBox {
+    T x1 = 0;
+    T x2 = 0;
+    T y1 = 0;
+    T y2 = 0;
+    T z1 = 0;
+    T z2 = 0;
 
-    bool ContainsXY(int x, int y) const {
+    bool ContainsXY(T x, T y) const {
         return x >= x1 && x <= x2 && y >= y1 && y <= y2;
     }
 
-    bool Contains(const Vec3_short_ &pos) const {
+    bool Contains(const Vec3<T> &pos) const {
         return x1 <= pos.x && pos.x <= x2 && y1 <= pos.y && pos.y <= y2 && z1 <= pos.z && pos.z <= z2;
     }
-};
-#pragma pack(pop)
 
-#pragma pack(push, 1)
-struct BBox_int_ {
-    int x1 = 0;
-    int x2 = 0;
-    int y1 = 0;
-    int y2 = 0;
-    int z1 = 0;
-    int z2 = 0;
-
-    bool Intersects(const BBox_short_ &other) const {
-        return
-            this->x1 <= other.x2 && this->x2 >= other.x1 &&
-            this->y1 <= other.y2 && this->y2 >= other.y1 &&
-            this->z1 <= other.z2 && this->z2 >= other.z1;
-    }
-
-    bool Intersects(const BBox_int_ &other) const {
+    template<class U>
+    bool Intersects(const BBox<U> &other) const {
         return
             this->x1 <= other.x2 && this->x2 >= other.x1 &&
             this->y1 <= other.y2 && this->y2 >= other.y1 &&
@@ -233,6 +217,10 @@ struct BBox_int_ {
     }
 };
 #pragma pack(pop)
+
+using BBox_int_ = BBox<int>;
+using BBox_short_ = BBox<short>;
+using BBox_float_ = BBox<float>;
 
 #pragma pack(push, 1)
 struct Plane_float_ {

--- a/Engine/VectorTypes.h
+++ b/Engine/VectorTypes.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cmath>
 #include <type_traits>
+#include <algorithm>
 
 #include "OurMath.h"
 
@@ -258,7 +259,6 @@ struct Plane_float_ {
     float SignedDistanceTo(const Vec3_float_ &point) {
         return this->dist + this->vNormal.x * point.x + this->vNormal.y * point.y + this->vNormal.z * point.z;
     }
-
 };
 #pragma pack(pop)
 

--- a/Engine/VectorTypes.h
+++ b/Engine/VectorTypes.h
@@ -200,6 +200,17 @@ struct BBox {
     T z1 = 0;
     T z2 = 0;
 
+    static BBox FromPoint(const Vec3<T> &center, T radius) {
+        BBox result;
+        result.x1 = center.x - radius;
+        result.x2 = center.x + radius;
+        result.y1 = center.y - radius;
+        result.y2 = center.y + radius;
+        result.z1 = center.z - radius;
+        result.z2 = center.z + radius;
+        return result;
+    }
+
     bool ContainsXY(T x, T y) const {
         return x >= x1 && x <= x2 && y >= y1 && y <= y2;
     }
@@ -214,6 +225,17 @@ struct BBox {
             this->x1 <= other.x2 && this->x2 >= other.x1 &&
             this->y1 <= other.y2 && this->y2 >= other.y1 &&
             this->z1 <= other.z2 && this->z2 >= other.z1;
+    }
+
+    friend BBox operator|(const BBox &l, const BBox &r) {
+        BBox result;
+        result.x1 = std::min(l.x1, r.x1);
+        result.x2 = std::max(l.x2, r.x2);
+        result.y1 = std::min(l.y1, r.y1);
+        result.y2 = std::max(l.y2, r.y2);
+        result.z1 = std::min(l.z1, r.z1);
+        result.z2 = std::max(l.z2, r.z2);
+        return result;
     }
 };
 #pragma pack(pop)

--- a/Engine/VectorTypes.h
+++ b/Engine/VectorTypes.h
@@ -36,14 +36,16 @@ const float pi = static_cast<float>(M_PI);
 
 #pragma pack(push, 1)
 template <class T>
-struct Vec3 : public Vec2<T> {
+struct Vec3 {
+    T x;
+    T y;
     T z;
 
-    explicit Vec3(T a = 0, T b = 0, T c = 0) : Vec2<T>(a, b), z(c) {}
+    explicit Vec3(T a = 0, T b = 0, T c = 0) : x(a), y(b), z(c) {}
 
     // TODO: rewrite with requires clause when we have C++20
     template<class OtherT, class = std::enable_if_t<vector_conversion_allowed<OtherT, T>::value>>
-    Vec3(const Vec3<OtherT> &other) : Vec2<T>(other.x, other.y), z(other.z) {}
+    Vec3(const Vec3<OtherT> &other) : x(other.x), y(other.y), z(other.z) {}
 
     template <class U>
     inline uint32_t GetDistanceTo(Vec3<U> &o) {

--- a/Engine/mm7_data.cpp
+++ b/Engine/mm7_data.cpp
@@ -16,10 +16,9 @@
 #include "MapInfo.h"
 #include "OurMath.h"
 
-struct TrigTableLookup* TrigLUT = new TrigTableLookup;
-struct MapStats *pMapStats;
-struct Viewport *pViewport = new Viewport;
-struct ViewingParams *viewparams = new ViewingParams;
+MapStats *pMapStats;
+Viewport *pViewport = new Viewport;
+ViewingParams *viewparams = new ViewingParams;
 stru123 stru_5E4C90_MapPersistVars;
 stru298 AttackerInfo;
 std::array<Autonote, 196> pAutonoteTxt;

--- a/Engine/stru314.h
+++ b/Engine/stru314.h
@@ -16,7 +16,6 @@ struct stru314 {  // facet normals face / wall / celings
         this->field_1C.x = 0.0;
         this->field_1C.y = 0.0;
         this->field_1C.z = 0.0;
-        // this->vdestructor_ptr = &stru314_pvdtor;
 
         this->dist = 0;
     }
@@ -24,7 +23,6 @@ struct stru314 {  // facet normals face / wall / celings
     //----- (00489B96) --------------------------------------------------------
     inline ~stru314() {}
 
-    void (***vdestructor_ptr)(stru314 *, bool) = nullptr;
     Vec3_float_ Normal;
     Vec3_float_ field_10;
     Vec3_float_ field_1C;

--- a/GUI/UI/Books/MapBook.cpp
+++ b/GUI/UI/Books/MapBook.cpp
@@ -306,14 +306,14 @@ void DrawBook_Map_sub(unsigned int tl_x, unsigned int tl_y, unsigned int br_x, i
     if (DrawArrow == 1) {
         int ArrowOctant = 0;
         int PartyDirection = pParty->sRotationZ & TrigLUT->uDoublePiMask;
-        if ((signed int)PartyDirection <= 1920) ArrowOctant = 6;
-        if ((signed int)PartyDirection < 1664) ArrowOctant = 5;
-        if ((signed int)PartyDirection <= 1408) ArrowOctant = 4;
-        if ((signed int)PartyDirection < 1152) ArrowOctant = 3;
-        if ((signed int)PartyDirection <= 896) ArrowOctant = 2;
-        if ((signed int)PartyDirection < 640) ArrowOctant = 1;
-        if ((signed int)PartyDirection <= 384) ArrowOctant = 0;
-        if ((signed int)PartyDirection < 128 || (signed int)PartyDirection > 1920) ArrowOctant = 7;
+        if (PartyDirection <= 1920) ArrowOctant = 6;
+        if (PartyDirection < 1664) ArrowOctant = 5;
+        if (PartyDirection <= 1408) ArrowOctant = 4;
+        if (PartyDirection < 1152) ArrowOctant = 3;
+        if (PartyDirection <= 896) ArrowOctant = 2;
+        if (PartyDirection < 640) ArrowOctant = 1;
+        if (PartyDirection <= 384) ArrowOctant = 0;
+        if (PartyDirection < 128 || PartyDirection > 1920) ArrowOctant = 7;
 
         render->DrawTransparentRedShade(ArrowXPos / 640.0f, ArrowYPos / 480.0f, game_ui_minimap_dirs[ArrowOctant]);
     }

--- a/Platform/Lin/Lin.cpp
+++ b/Platform/Lin/Lin.cpp
@@ -2,6 +2,7 @@
 
 #include <SDL.h>
 #include <dirent.h>
+#include <glob.h>
 #include <fnmatch.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
* Added docs here and there.
* Cleaned up formatting in some places / dropped some dead code.
* Fixed #251.
* Fixed #256 (input on this is welcome).
* Refactored implementation of Vec / BBox classes --- merged several implementations into one.
* Using floating point math in collision detection, and thus in movement --- this makes moving around on high fps nice and smooth.
* TrigLUT now also uses floats, dropped quite a lot of code there, and got rid of a lot of fixpoint math at call sites.
* Fixed a crash when staying indoors in a sector with a high id and then loading a savegame and going into a dungeon that doesn't even have a sector with this id (this one was introduced in one of the recent PRs).
* Fixed an infinite loop in SpriteObject::UpdateObject_fn0_ODM --- it could be triggered by casting a lot of meteor showers / fireballs.
* Fixed a crash when casting souldrinker while spell particles are in sight (there is still a minor bug left --- try casting souldrinker when e.g. a dragon is firing at you, and you'll see his firebolt slightly changing direction).