### PR TITLE
Further doxygen improvements

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -7,7 +7,7 @@ on:
     types: published
 
 jobs:
-  generate:
+  generate_documentation:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
@@ -32,10 +32,10 @@ jobs:
         name: Documentation
         path: docs/html
 
-  deploy:
+  deploy_documentation:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
-    needs: generate
+    needs: generate_documentation
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -26,11 +26,23 @@ jobs:
         ./doxygen Doxyfile
         touch docs/html/.nojekyll
 
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: Documentation
+        path: docs/html
+
   deploy:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     needs: generate
-    if: github.ref == 'refs/heads/master'
     steps:
+    - name: Download Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: Documentation
+        path: docs/html
+
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -17,12 +17,13 @@ jobs:
 
     - name: Install Doxygen
       run: |
-        sudo apt-get install doxygen -y
+        # sudo apt-get install doxygen -y
+        curl https://www.doxygen.nl/files/doxygen-1.9.5.linux.bin.tar.gz | tar xzf - --strip-components=2 doxygen-1.9.5/bin/doxygen -C .
 
     - name: Generate Documentation
       run: |
         export PROJECT_NUMBER="$(git describe --always --tags --dirty)"
-        doxygen Doxyfile
+        ./doxygen Doxyfile
         touch docs/html/.nojekyll
 
   deploy:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-22.04
     needs: generate
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
+
     - name: Download Artifact
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,12 +1,13 @@
 name: Doxygen
 
 on:
+  pull_request:
   push:
-    branches:
-      - master
+  release:
+    types: published
 
 jobs:
-  deploy:
+  generate:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
@@ -24,6 +25,11 @@ jobs:
         doxygen Doxyfile
         touch docs/html/.nojekyll
 
+  deploy:
+    runs-on: ubuntu-22.04
+    needs: generate
+    if: github.ref == 'refs/heads/master'
+    steps:
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:
@@ -31,4 +37,3 @@ jobs:
         branch: gh-pages
         folder: docs/html
         target-folder: .
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "thirdparty/luajit"]
 	path = thirdparty/luajit/luajit
 	url = https://github.com/LuaJIT/LuaJIT
+	branch = v2.1
 [submodule "thirdparty/glm"]
 	path = thirdparty/glm
 	url = https://github.com/g-truc/glm

--- a/Doxyfile
+++ b/Doxyfile
@@ -354,7 +354,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -791,7 +791,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -841,7 +841,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -983,7 +983,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = build docs lib out thirdparty
+EXCLUDE                = build docs lib out thirdparty Launcher
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/HACKING.md
+++ b/HACKING.md
@@ -50,8 +50,8 @@ You will require the following installed on your computer: Git and Visual Studio
 
 * Clone, fork or download the repo `https://github.com/gp-alex/world-of-might-and-magic.git`
 * Open the folder in Visual Studio
-* Select build configuration (x32 or x64) and wait for CMake cache to complete
-* Select startup item as World of Might and Magic
+* Select build configuration (x32 or x64) and wait for CMake configuration to complete
+* Select startup item as `World_of_Might_and_Magic.exe`
 * Run!
 
 __Be aware__ that Visual Studio has a bug with git submodules not syncing between branches.
@@ -59,7 +59,7 @@ So when checking out the branch or switching to different branch you may need to
 
 Support
 ---------------
-Still having problems? Try the ask for help on our discord. [![](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq)
+Still having problems? Try to ask for help on our discord. [![](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq)
 
 
 Coding style

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,16 +1,20 @@
+﻿# Building instructions and guidance
 
-Build from repository
----------------------
+This document contains information about required dependencies and various guidance about compilation and development processes.
 
-This project uses the [CMake](https://cmake.org) build system.
-Use the following commands to build (it is recommended to build in a separate directory as shown here):
+Dependencies
+---------------
+Main dependencies:
+* [SDL2](https://www.libsdl.org/download-2.0.php) - crossplatform media framework
+* [FFmpeg](https://ffmpeg.zeranoe.com/builds/) - video support
+* [OpenAL](https://www.openal.org/downloads/OpenAL11CoreSDK.zip) - audio support
+* [Zlib](http://gnuwin32.sourceforge.net/packages/zlib.htm) - compression
 
-``` shell
-$ mkdir build && cd build
-$ cmake ..
-$ make
-```
-or select platform dependent [generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) for your favorite IDE.
+On windows above dependencies are resolved automatically during cmake phase but you must also have Windows SDK v10.0.20348.0 or higher installed.
+
+Additional dependencies:
+* CMake 3.20+ with exception of 3.20.21032501-MSVC_2 from VS2019
+* Python 3.x (optional, for style checker functionality)
 
 Minimum required compiler versions are as follows:
 * Visual Studio 2019
@@ -18,52 +22,56 @@ Minimum required compiler versions are as follows:
 * Clang 13
 
 The following IDEs have been tested and should work fine:
-* Visual Studio 2019
+* Visual Studio 2019 or later
 * Visual Studio Code (2022 or later)
 * CLion (2022 or later)
 
+Building on \*nix platforms
+---------------
+This project uses the [CMake](https://cmake.org) build system.
+Use the following commands to clone repository and build (it is recommended to build in a separate directory as shown here):
 
-Dependencies
-------------
+```
+$ git clone https://github.com/gp-alex/world-of-might-and-magic.git
+$ cd world-of-might-and-magic
+$ mkdir build && cd build
+$ cmake ..
+$ make
+```
 
-* [SDL2](https://www.libsdl.org/download-2.0.php) - crossplatform media framework
-* [FFmpeg](https://ffmpeg.zeranoe.com/builds/) - video support
-* [OpenAL](https://www.openal.org/downloads/OpenAL11CoreSDK.zip) - audio support
-* [zlib](http://gnuwin32.sourceforge.net/packages/zlib.htm) - compression
+To compile x86 build on x86_64 platform you can pass `-m32` via compiler flags to cmake.
+For example instead of just `cmake ..` above execute `CFLAGS="-m32" CXXFLAGS="-m32" cmake ..`
 
-These are now auto-resolved during CMake build.
+You can also select platform dependent [generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) for your favorite IDE.
 
+Building on Windows
+---------------
+You will require the following installed on your computer: Git and Visual Studio 2019/2022.
 
-Instructions
-------------
-You will require the following installed on your computer: Git and Visual Studio 2019.
-
-* Clone, fork or download the repo "https://github.com/gp-alex/world-of-might-and-magic.git"
+* Clone, fork or download the repo `https://github.com/gp-alex/world-of-might-and-magic.git`
 * Open the folder in Visual Studio
 * Select build configuration (x32 or x64) and wait for CMake cache to complete
 * Select startup item as World of Might and Magic
 * Run!
 
-Visual studio has a bug with git submodules not syncing between branches.
-When checking out the branch you may need to run the following command: "git submodule update --init"
+__Be aware__ that Visual Studio has a bug with git submodules not syncing between branches.
+So when checking out the branch or switching to different branch you may need to run the following command manually: `git submodule update --init`
 
-MSVC users please note this project requires Windows SDK 10.0.20348.0 or higher
-
-Still having problems? Try the discord chat [![](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq)
+Support
+---------------
+Still having problems? Try the ask for help on our discord. [![](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq)
 
 
 Coding style
-------------
-For the C++ code we are following the [Google C++ Style Guide](http://google.github.io/styleguide/cppguide.html).<br />
-Source code is automatically checked against it, and Pull Request will fail if you don't follow it.<br />
-For style check on Windows platform, you can use [Visual Studio Code cpplint plugin](https://marketplace.visualstudio.com/items?itemName=mine.cpplint).
+---------------
+For the C++ code we are following the [Google C++ Style Guide](http://google.github.io/styleguide/cppguide.html).\
+Source code is automatically checked against it and Pull Request will fail if you don't follow it.
 
-In visual studio, style can be checked (Python requred). Go to Solution Explorer->Change Views->CMake targets
-Right click and build check_style, errors will be listed in output
+To perform style check before pushing anything you can build `check_style` target. In Visual Studio you can do that by going to ***Solution Explorer → Change Views → CMake targets***. Right click and build `check_style`, errors will be listed in output.
 
 Some additional style preferences that we follow, in no particular order:
 * `*` and `&` in type declarations are preceded by a space. So it's `char *string`, and not `char* string`.
-* Documentation should be in doxydoc format with `\` used for tags, and starting with `/**` comment introducer.
+* Documentation should be in doxydoc format with `@` used for tags, and starting with `/**` comment introducer.
 * Documentation should be written in English. There are some leftover comments in Russian throughout the codebase, feel free to translate them into English when you have a chance.
-* Please leave original function offsets intact (eg '//----- (00436523)')
+* Please leave original function offsets intact. If you have a chance move them to doxygen comments using offset alias (eg `@offset 0xCAFEBEEF.`)
 * Use `enum class`es followed by `using enum` statements instead of ordinary `enum`s. This provides type safety without changing the syntax. For flags, use `Flags` class.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Currently only MM7 is playable. Support for 6 & 8 will be added in the future.
 
 [![Windows](https://github.com/gp-alex/world-of-might-and-magic/workflows/Windows/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/windows.yml) [![Linux](https://github.com/gp-alex/world-of-might-and-magic/workflows/Linux/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/linux.yml) [![MacOS](https://github.com/gp-alex/world-of-might-and-magic/workflows/MacOS/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/macos.yml) [![AppVeyor](https://ci.appveyor.com/api/projects/status/nlno5vo74jf6rnt3/branch/master?svg=true&passingText=passing&failingText=failing&pendingText=pending)](https://ci.appveyor.com/project/gp-alex/world-of-might-and-magic)
 
-[![Style Checker](https://github.com/gp-alex/world-of-might-and-magic/workflows/Style/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/style.yml) [![Coverity Status](https://scan.coverity.com/projects/16434/badge.svg)](https://scan.coverity.com/projects/world-of-might-and-magic)
+[![Doxygen](https://github.com/gp-alex/world-of-might-and-magic/workflows/Doxygen/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/doxygen.yml) [![Style Checker](https://github.com/gp-alex/world-of-might-and-magic/workflows/Style/badge.svg)](https://github.com/gp-alex/world-of-might-and-magic/actions/workflows/style.yml) [![Coverity Status](https://scan.coverity.com/projects/16434/badge.svg)](https://scan.coverity.com/projects/world-of-might-and-magic)
 
 ![screenshot_main](https://user-images.githubusercontent.com/24377109/79051217-491a7800-7c2f-11ea-85c7-f9120b7d79dd.png)
 
-Discord [![Discord channel invite](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq) 
+Discord
 ---------------
 Join our discord channel to discuss, track progress or involve in development of this project.
 
+[![Discord channel invite](https://img.shields.io/badge/chat-on%20discord-green.svg)](https://discord.gg/jRCyPtq) 
 
 Getting Started
 ---------------

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Join our discord channel to discuss, track progress or involve in development of
 
 Getting Started
 ---------------
-1. You will require a GoG or any older version of Might and Magic 7 installed for engine to guess game assets folder. You can override  assets/game path in launcher or by using WOMM_PATH_OVERRIDE env variable.
-2. Use any IDE with CMake integration (Visual Studio is good).
-2. Build & run game directly, or via launcher.
+1. You will require a GoG or any older version of Might and Magic 7 installed for engine to guess game assets folder. You can override assets/game path in launcher or by using WOMM_PATH_OVERRIDE env variable.
+2. Use any IDE with CMake integration.
+3. Build & run game directly, or via launcher.
 
 Development
 ---------------

--- a/TODO.md
+++ b/TODO.md
@@ -1,32 +1,28 @@
-# TODO:
+# General TODO list
 
-* Move all water anim to TextureFrameTable to avoid many duplication of water animation handling code*
+* Move all water anim to `TextureFrameTable` to avoid many duplication of water animation handling code.
 
-* Quicksave / Quickload
+* Implement Quicksave / Quickload.
 
-* add short term / long term project goals - expand milestones
+* Add short term / long term project goals - expand milestones.
 
-* spiders not masking skull texture?
+* Are spiders not masking skull texture?
 
-* Rename unidentifed variables
-* Remove all platform dependant fucntions
+* Rename unidentifed variables.
+* Remove all platform-dependant functions.
 
-* is spirit resistacne a thing or not?
+* Is spirit resistance a thing or not?
 
 * Additional features:
-- Harden party logic so that team size can be varied
-- map editor? i think there was a semi complete example somewhere
+  - Harden party logic so that team size can be varied.
+  - Map editor? i think there was a semi complete example somewhere.
 
-
-* QOL improvements:
--  global merchant/ identify skills?
-
+* QoL improvements:
+  - global merchant / identify skills?
 
 * Possible graphics improvements:
-- keep track of light source intensity and add subtle flicker effect. proof of concept Engine/Graphics/Indoor.cpp line 115.
-
-
+  - keep track of light source intensity and add subtle flicker effect. proof of concept Engine/Graphics/Indoor.cpp line 115.
 
 * Optimization targets:
-- Currently engine fps is heavily CPU bound in directX mode. This is because of the amount of draw calls outside, optimized batching on draw terrain traingles will give FPS boost
+  - Currently engine fps is heavily CPU bound in directX mode. This is because of the amount of draw calls outside, optimized batching on draw terrain traingles will give FPS boost.
 


### PR DESCRIPTION
- try to generate documentation on any push/pr, but deploy only if it is master branch
- show only warnings and switch failing on warnings to fail_on_warnings
- enable stl support
- exclude Launcher as it seems it is the source of doxygen confusion with Application namespace
- doxygen artifact
- use static 1.9.5 doxygen build from official site
- add doxygen badge and move discord badge from title
- typo fixes and improvements in README.md/HACKING.md/TODO.md
- bump luajit to latest v2.1 commit
