### PR TITLE
Fix NULL dereferencing in OpenGL code

### DIFF
--- a/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
+++ b/src/Engine/Graphics/OpenGL/RenderOpenGL.cpp
@@ -4937,6 +4937,7 @@ void RenderOpenGL::DrawIndoorFaces() {
                             for (int z = 0; z < (face->uNumVertices - 2); z++) {
                                 // 123, 134, 145, 156..
                                 GLshaderverts *thisvert = &BSPshaderstore[texunit][numBSPverts[texunit]];
+                                if (!thisvert) continue;
 
 
                                 // copy first


### PR DESCRIPTION
ArchLinux, latest build with forcibly defined `FF_API_NEXT` because of #319. The crash was happening when triggering the fountains in the walls of mist.

I must specify I don't know what I'm doing: I just found `thisvert` was NULL and added a guard.