### PR TITLE
fix rename() failing on linux when paths are on a different mount points

### DIFF
--- a/src/Engine/LOD.cpp
+++ b/src/Engine/LOD.cpp
@@ -504,7 +504,8 @@ bool LOD::WriteableFile::FixDirectoryOffsets() {
     CloseWriteFile();
     std::filesystem::remove(MakeTempPath("lodapp.tmp"));
     std::filesystem::remove(pLODPath);
-    std::filesystem::rename(tempPath, pLODPath);
+    std::filesystem::copy(tempPath, pLODPath);
+    std::filesystem::remove(tempPath);
     CloseWriteFile();
 
     return LoadFile(pLODPath, 0);
@@ -676,7 +677,8 @@ unsigned int LOD::WriteableFile::Write(const std::string &file_name, const void 
     fclose(tmp_file);
     CloseWriteFile();
     std::filesystem::remove(pLODPath);
-    std::filesystem::rename(tempPath, pLODPath);
+    std::filesystem::copy(tempPath, pLODPath);
+    std::filesystem::remove(tempPath);
     CloseWriteFile();
 
     // reload new


### PR DESCRIPTION
hello,

rename() does not work across different mount points, even if the same filesystem is mounted on both

some people with linux installs use different partitions for /home /tmp and other directories.
in such configurations filesystem::rename will throw an exception

consider using combination of copy + remove as it is a bit more robust and the overhead is 
not significant in this case